### PR TITLE
fix(agents): enable bash tools for gh CLI

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -73,6 +73,9 @@ jobs:
             If stuck for 30min or CI fails 3x, escalate to @jeremy.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: 45
+          claude_args: |
+            --dangerously-skip-permissions
+            --allowedTools "Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(cd:*),Bash(uv:*),Read,Write,Edit,Glob,Grep"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -46,6 +46,9 @@ jobs:
 
             Available labels: bug, enhancement, ai-ready, P0, P1, P2, needs-human
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --dangerously-skip-permissions
+            --allowedTools "Bash(gh issue:*),Bash(gh search:*),Read,Glob,Grep"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added --dangerously-skip-permissions and --allowedTools to enable agents to use gh CLI commands.