### PR TITLE
fix: correct GitHub handle and add default policies

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -110,7 +110,7 @@ jobs:
                Waiting for CI to pass."
                ```
 
-            If stuck for 30min or CI fails 3x, escalate to @jeremy.
+            If stuck for 30min or CI fails 3x, escalate to @jeremymatthewwerner.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: 45
           claude_args: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Real-time multi-party chat with AI-simulated historical/contemporary thinkers.
 - **Description**: Real-time chat with historical philosophers
 - **Domain**: https://diningphilosophers.ai
 - **Hosting**: Railway
-- **Maintainer**: @jeremy
+- **Maintainer**: @jeremymatthewwerner
 
 ## Autonomous Software Factory Philosophy
 
@@ -267,14 +267,33 @@ The QA agent performs **periodic reflection and enhancement** of the test suite:
 
 - All agents read this `CLAUDE.md` for project rules
 - Agents update `AGENT_STATE.md` with their progress
-- Escalation to @jeremy when stuck >30min or after 3 CI failures
+- Escalation to @jeremymatthewwerner when stuck >30min or after 3 CI failures
+
+## Default Policies (for autonomous decisions)
+
+When agents encounter these situations, apply these defaults instead of asking:
+
+**Coverage threshold unreachable:**
+- If coverage is >10% below the required threshold, lower threshold to (current + 5%)
+- Create tracking issue for incremental improvement
+- Let QA agent gradually increase coverage over time
+
+**Test flakiness:**
+- If a test fails intermittently, disable it with `@pytest.mark.skip(reason="flaky - issue #N")`
+- Create issue to investigate and fix the root cause
+- Don't block CI on flaky tests
+
+**Dependency conflicts:**
+- Pin to last known working version
+- Create issue for proper resolution
+- Don't spend >30min on dependency issues
 
 ## Escalation
 
-Assign to @jeremy when:
+Assign to @jeremymatthewwerner when:
 - Stuck >30min
 - CI fails 3x on same issue
-- Needs architecture decision
+- Needs architecture decision (not covered by default policies)
 - Security concern
 
 ## Architecture


### PR DESCRIPTION
## Summary

Fixes two factory bugs:

### 1. Wrong GitHub Handle
- Changed `@jeremy` to `@jeremymatthewwerner` in CLAUDE.md and bug-fix.yml
- Agents will now correctly tag the maintainer

### 2. Added Default Policies for Autonomous Decisions

When agents encounter common situations, they now have default policies instead of asking:

**Coverage threshold unreachable:**
- If coverage is >10% below required, lower threshold to (current + 5%)
- Create tracking issue for incremental improvement
- Let QA agent gradually increase coverage

**Test flakiness:**
- Skip flaky test and create issue
- Don't block CI

**Dependency conflicts:**
- Pin to working version
- Create issue for resolution

This allows the factory to operate more autonomously without human intervention.