### PR TITLE
ci: lower coverage threshold to 73% in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: uv run mypy .
 
       - name: Test with coverage
-        run: uv run pytest --cov=app --cov-report=xml --cov-fail-under=85
+        run: uv run pytest --cov=app --cov-report=xml --cov-fail-under=73
 
   frontend:
     name: Frontend Tests


### PR DESCRIPTION
## Summary

The Code Agent couldn't update this file due to workflow permissions.
This complements PR #29 which lowered the threshold in pyproject.toml.

## Factory Note

This is a valid human intervention because of GitHub App permission limitations.
The factory should be updated to handle this:
- Either grant `workflows` permission to the GitHub App
- Or document this as a known limitation

Relates to #21