### PR TITLE
feat(agents): add comment-driven interaction with @claude mentions

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -2,6 +2,8 @@ name: Code Agent
 on:
   issues:
     types: [labeled]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       issue_number:
@@ -15,14 +17,27 @@ permissions:
   pull-requests: write
   id-token: write
 
+# Prevent concurrent runs on the same issue
+concurrency:
+  group: code-agent-issue-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: false
+
 jobs:
   fix:
-    # Triggers on ai-ready + (bug OR enhancement)
+    # Triggers on:
+    # 1. ai-ready label + (bug OR enhancement)
+    # 2. Comment containing @claude on an issue with ai-ready label
+    # 3. Manual workflow dispatch
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event.label.name == 'ai-ready' &&
+      (github.event_name == 'issues' &&
+       github.event.label.name == 'ai-ready' &&
        (contains(github.event.issue.labels.*.name, 'bug') ||
-        contains(github.event.issue.labels.*.name, 'enhancement')))
+        contains(github.event.issue.labels.*.name, 'enhancement'))) ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(github.event.issue.labels.*.name, 'ai-ready') &&
+       !github.event.issue.pull_request)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -50,39 +65,69 @@ jobs:
         working-directory: backend
         run: uv sync || true
 
-      - name: Get issue number
-        id: issue
+      - name: Get issue number and context
+        id: context
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "number=${{ github.event.inputs.issue_number }}" >> $GITHUB_OUTPUT
+            echo "mode=fix" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" == "issue_comment" ]; then
+            echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+            echo "mode=respond" >> $GITHUB_OUTPUT
+            echo "comment_author=${{ github.event.comment.user.login }}" >> $GITHUB_OUTPUT
           else
             echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+            echo "mode=fix" >> $GITHUB_OUTPUT
           fi
 
-      - name: Mark issue as in progress
+      - name: Update status labels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh issue comment ${{ steps.issue.outputs.number }} --body "## 🤖 Code Agent Started
+          # Remove other status labels and add bot-working
+          gh issue edit ${{ steps.context.outputs.number }} \
+            --remove-label "status:awaiting-human" \
+            --remove-label "status:awaiting-bot" 2>/dev/null || true
+          gh issue edit ${{ steps.context.outputs.number }} \
+            --add-label "status:bot-working"
+
+      - name: Mark issue as in progress (fix mode)
+        if: steps.context.outputs.mode == 'fix'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ steps.context.outputs.number }} --body "## 🤖 Code Agent Started
 
           **Status:** Analyzing issue...
           **Workflow Run:** [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           I'll update this issue with my progress."
 
-      - uses: anthropics/claude-code-action@v1
+      - name: Acknowledge comment (respond mode)
+        if: steps.context.outputs.mode == 'respond'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ steps.context.outputs.number }} --body "## 🤖 Responding to @${{ steps.context.outputs.comment_author }}
+
+          **Status:** Processing your comment...
+          **Workflow Run:** [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
+      - name: Run Claude (fix mode)
+        if: steps.context.outputs.mode == 'fix'
+        uses: anthropics/claude-code-action@v1
         with:
           prompt: |
             Read CLAUDE.md and .claude/agents/bug-fixer.md first.
 
-            **IMPORTANT: You MUST update issue #${{ steps.issue.outputs.number }} with your progress!**
+            **IMPORTANT: You MUST update issue #${{ steps.context.outputs.number }} with your progress!**
 
             ## Step 1: Analyze (UPDATE ISSUE AFTER)
-            1. Read the issue: gh issue view ${{ steps.issue.outputs.number }}
+            1. Read the issue: gh issue view ${{ steps.context.outputs.number }}
             2. Diagnose the root cause - search codebase, read relevant files
             3. **Update the issue** with your analysis:
                ```bash
-               gh issue comment ${{ steps.issue.outputs.number }} --body "## Analysis
+               gh issue comment ${{ steps.context.outputs.number }} --body "## Analysis
 
                **Root Cause:** [what's wrong]
                **Files Affected:** [list files]
@@ -90,18 +135,18 @@ jobs:
                ```
 
             ## Step 2: Implement Fix
-            1. Create a fix branch: git checkout -b fix/${{ steps.issue.outputs.number }}-description
+            1. Create a fix branch: git checkout -b fix/${{ steps.context.outputs.number }}-description
             2. Implement the fix with tests
             3. Run quality gates:
                - cd frontend && npm run lint && npm run typecheck && npm test
                - cd backend && uv run ruff check . && uv run mypy . && uv run pytest
 
             ## Step 3: Create PR (UPDATE ISSUE AFTER)
-            1. Commit with message referencing issue: "fix: description\n\nFixes #${{ steps.issue.outputs.number }}"
-            2. Push and create PR: gh pr create --title "fix: ..." --body "Fixes #${{ steps.issue.outputs.number }}"
+            1. Commit with message referencing issue: "fix: description\n\nFixes #${{ steps.context.outputs.number }}"
+            2. Push and create PR: gh pr create --title "fix: ..." --body "Fixes #${{ steps.context.outputs.number }}"
             3. **Update the issue** with PR link:
                ```bash
-               gh issue comment ${{ steps.issue.outputs.number }} --body "## ✅ Fix Submitted
+               gh issue comment ${{ steps.context.outputs.number }} --body "## ✅ Fix Submitted
 
                **PR:** #[number]
                **Changes:** [summary]
@@ -109,6 +154,10 @@ jobs:
 
                Waiting for CI to pass."
                ```
+
+            ## Status Label Management
+            - If you need human input, run: gh issue edit ${{ steps.context.outputs.number }} --remove-label "status:bot-working" --add-label "status:awaiting-human"
+            - When done (PR created or issue resolved), remove status:bot-working label
 
             If stuck for 30min or CI fails 3x, escalate to @jeremymatthewwerner.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -120,14 +169,68 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Run Claude (respond mode)
+        if: steps.context.outputs.mode == 'respond'
+        uses: anthropics/claude-code-action@v1
+        with:
+          prompt: |
+            Read CLAUDE.md first.
+
+            A user (@${{ steps.context.outputs.comment_author }}) has commented on issue #${{ steps.context.outputs.number }} with a question or suggestion for you.
+
+            ## Your Task
+            1. Read the full issue and all comments: gh issue view ${{ steps.context.outputs.number }} --comments
+            2. Focus on the latest comment from @${{ steps.context.outputs.comment_author }}
+            3. Think carefully about their question/suggestion
+            4. If it's a clarifying question: Answer it thoughtfully
+            5. If it's a suggestion about the fix: Consider it and explain if/how you'll incorporate it
+            6. If they're asking you to take action: Do it if reasonable
+
+            ## After Thinking
+            Post a response to the issue:
+            ```bash
+            gh issue comment ${{ steps.context.outputs.number }} --body "## Response
+
+            [Your thoughtful response here, addressing their specific points]
+
+            [If you took any action, describe what you did]
+            [If you need more info, ask a specific question and add status:awaiting-human label]"
+            ```
+
+            ## Status Label Management
+            - If you need more info from the human: gh issue edit ${{ steps.context.outputs.number }} --remove-label "status:bot-working" --add-label "status:awaiting-human"
+            - If you've fully addressed their comment and no more action needed: remove status:bot-working
+            - If there's still work to do on the issue, keep status:bot-working
+
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          timeout_minutes: 30
+          claude_args: |
+            --dangerously-skip-permissions
+            --allowedTools "Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(cd:*),Bash(uv:*),Read,Write,Edit,Glob,Grep"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update status on success
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Remove bot-working status when done (Claude should have set appropriate status)
+          gh issue edit ${{ steps.context.outputs.number }} \
+            --remove-label "status:bot-working" 2>/dev/null || true
+
       - name: Update issue on failure
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh issue comment ${{ steps.issue.outputs.number }} --body "## ❌ Code Agent Failed
+          gh issue comment ${{ steps.context.outputs.number }} --body "## ❌ Code Agent Failed
 
           The workflow encountered an error. Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 
           This issue remains open for manual follow-up."
-          gh issue edit ${{ steps.issue.outputs.number }} --add-label "needs-human"
+          gh issue edit ${{ steps.context.outputs.number }} \
+            --remove-label "status:bot-working" \
+            --add-label "needs-human" \
+            --add-label "status:awaiting-human"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@ Create these labels (or run: `gh label create <name> --color <color>`):
 - `qa-agent` (#0052CC) - QA Agent tracking issues
 - `automation` (#BFDADC) - Automated by agents
 - `ci-failure` (#B60205) - CI failure issues
+- `status:bot-working` (#7057FF) - Bot is actively working on this issue
+- `status:awaiting-human` (#D93F0B) - Blocked waiting for human input
+- `status:awaiting-bot` (#0E8A16) - Human commented, bot will respond
 - `bug`, `enhancement`, `priority-high`, `priority-medium`, `priority-low`
 
 ### 3. Secrets
@@ -267,6 +270,32 @@ All agents MUST post progress updates to their issues for visibility:
 1. Creates issue with `bug`, `priority-high`, `ci-failure` labels
 2. Adds `ai-ready` label separately (triggers Code Agent's `labeled` event)
 3. Code Agent picks up and attempts fix
+
+### Interacting with the Code Agent
+
+**Comment-driven interaction:** You can comment on any issue with `@claude` to ask questions or provide suggestions. The bot will:
+1. Read your comment and the full issue context
+2. Think about your question/suggestion
+3. Post a thoughtful response
+4. Take action if appropriate
+
+**Status labels indicate who should act next:**
+| Label | Meaning | Who Acts |
+|-------|---------|----------|
+| `status:bot-working` | Bot is actively working | Wait for bot |
+| `status:awaiting-human` | Bot needs your input | You respond |
+| `status:awaiting-bot` | You commented, bot will respond | Wait for bot |
+| (no status label) | No active work | Add `ai-ready` to trigger |
+
+**Example workflow:**
+1. Issue created with `bug` + `ai-ready` labels
+2. Bot starts → `status:bot-working`
+3. Bot has a question → `status:awaiting-human` + comment asking
+4. You reply with `@claude here's the answer...`
+5. Bot responds → `status:bot-working`
+6. Bot creates PR → removes status labels
+
+**Concurrency:** Only one bot run per issue at a time. Comments are queued, not dropped.
 
 ### QA Agent - Test Quality Guardian
 


### PR DESCRIPTION
## Summary
- Adds `@claude` mention support - comment on any `ai-ready` issue to interact with the bot
- Implements status labels to clarify who should act next (human vs bot)
- Adds concurrency handling to prevent race conditions on the same issue

## Changes

### New Features
1. **Comment-driven interaction**: Comment `@claude <your question>` on any issue with `ai-ready` label
2. **Status labels**: 
   - `status:bot-working` - Bot is actively working
   - `status:awaiting-human` - Bot needs human input
   - `status:awaiting-bot` - Human commented, bot will respond
3. **Two operation modes**:
   - `fix` mode: Initial issue work (analyze → implement → PR)
   - `respond` mode: Reply to human comments thoughtfully

### Concurrency
- Uses GitHub Actions concurrency groups per issue
- Queues (not cancels) concurrent runs
- Prevents race conditions when multiple comments come in

## Test plan
- [ ] Create test issue with `bug` + `ai-ready` labels
- [ ] Verify Code Agent starts and adds `status:bot-working`
- [ ] Comment `@claude what files are you looking at?`
- [ ] Verify bot responds to the comment
- [ ] Verify status labels transition correctly