### PR TITLE
feat(agents): add CI monitoring to Code Agent workflow

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -16,6 +16,8 @@ permissions:
   issues: write
   pull-requests: write
   id-token: write
+  actions: read
+  checks: read
 
 # Prevent concurrent runs on the same issue
 concurrency:
@@ -153,7 +155,7 @@ jobs:
                **Changes:** [summary]
                **Tests Added:** [list]
 
-               Waiting for CI to pass."
+               Waiting for CI to pass. I'll post an update when CI completes (typically 3-5 minutes)."
                ```
 
             ## Status Label Management
@@ -211,6 +213,59 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
           GITHUB_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
+
+      - name: Monitor CI and report results
+        if: steps.context.outputs.mode == 'fix' && success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Find the most recent PR created by this workflow
+          PR_NUMBER=$(gh pr list --state open --author "@me" --json number,headRefName --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR found, skipping CI monitoring"
+            exit 0
+          fi
+
+          echo "Monitoring CI for PR #$PR_NUMBER"
+
+          # Wait for CI to start
+          sleep 30
+
+          # Poll for up to 15 minutes (30 iterations * 30 seconds)
+          for i in $(seq 1 30); do
+            echo "Check $i/30..."
+
+            # Get check status
+            IN_PROGRESS=$(gh pr checks $PR_NUMBER --json state --jq '[.[] | select(.state=="PENDING" or .state=="IN_PROGRESS")] | length' 2>/dev/null || echo "0")
+
+            if [ "$IN_PROGRESS" = "0" ]; then
+              # All checks complete, get results
+              FAILED=$(gh pr checks $PR_NUMBER --json state --jq '[.[] | select(.state=="FAILURE")] | length' 2>/dev/null || echo "0")
+
+              if [ "$FAILED" -gt 0 ]; then
+                gh issue comment ${{ steps.context.outputs.number }} --body "## ❌ CI Failed
+
+          PR #${PR_NUMBER} has failing checks. [View details](https://github.com/${{ github.repository }}/pull/${PR_NUMBER})
+
+          I'll investigate the failures and push fixes."
+              else
+                gh issue comment ${{ steps.context.outputs.number }} --body "## ✅ CI Passed
+
+          All checks passed! [PR #${PR_NUMBER}](https://github.com/${{ github.repository }}/pull/${PR_NUMBER}) is ready for review and merge.
+
+          Once merged, this issue will auto-close."
+              fi
+              exit 0
+            fi
+
+            sleep 30
+          done
+
+          # Timeout - still running after 15 min
+          gh issue comment ${{ steps.context.outputs.number }} --body "## ⏳ CI Still Running
+
+          CI checks for PR #${PR_NUMBER} are still running after 15 minutes. [Check status](https://github.com/${{ github.repository }}/pull/${PR_NUMBER})"
 
       - name: Update status on success
         if: success()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,8 @@ All agents MUST post progress updates to their issues for visibility:
 1. "🤖 Code Agent Started" - with workflow link
 2. "## Analysis" - root cause, affected files, proposed fix
 3. "## ✅ Fix Submitted" - PR link, changes, tests added
-4. "## ❌ Failed" - error details, adds `needs-human` label
+4. "## ✅ CI Passed" or "## ❌ CI Failed" - automatic CI status update (typically 3-5 min after PR)
+5. "## ❌ Failed" - error details, adds `needs-human` label
 
 **QA Agent** creates a tracking issue for each run:
 1. Creates issue: "🤖 QA Agent: [focus] ([day])"


### PR DESCRIPTION
## Summary
Fixes the "stuck waiting for CI" issue from #30. After creating a PR, the Code Agent now automatically monitors CI and posts status updates.

## What This Fixes
Previously, the bot would post "Waiting for CI to pass" and then exit, leaving the human wondering if it was stuck. Now it:
1. Waits for CI checks to complete (polls every 30s for up to 15 min)
2. Posts "✅ CI Passed" or "❌ CI Failed" automatically
3. Includes links to the PR for easy access

## Changes
- Added `actions: read` and `checks: read` permissions to workflow
- Added "Monitor CI and report results" step after Claude runs in fix mode
- Updated "Waiting for CI" message to include time estimate
- Documented CI monitoring in CLAUDE.md

## Test plan
- [ ] Create a test issue with `bug` + `ai-ready` labels
- [ ] Bot creates a PR
- [ ] Bot posts "Waiting for CI... (typically 3-5 minutes)"
- [ ] After CI completes, bot posts "✅ CI Passed" or "❌ CI Failed"

Relates to #30