### PR TITLE
fix(agents): use gh api for progress comment creation

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -110,8 +110,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Create initial progress comment with checkboxes
-          COMMENT_URL=$(gh issue comment ${{ steps.context.outputs.number }} --body "## 🤖 Progress Tracker
+          # Create initial progress comment with checkboxes using gh api (returns comment ID)
+          COMMENT_BODY="## 🤖 Progress Tracker
 
           - [ ] 📖 Reading issue and understanding requirements
           - [ ] 🔍 Analyzing codebase and finding affected files
@@ -121,10 +121,11 @@ jobs:
           - [ ] 🚀 Waiting for CI
 
           **Status:** Starting analysis...
-          **Workflow:** [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" --json url --jq '.url')
+          **Workflow:** [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
-          # Extract comment ID from URL
-          COMMENT_ID=$(echo "$COMMENT_URL" | grep -oE '[0-9]+$')
+          COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/${{ steps.context.outputs.number }}/comments \
+            -X POST -f body="$COMMENT_BODY" --jq '.id')
+
           echo "comment_id=$COMMENT_ID" >> $GITHUB_OUTPUT
           echo "Created progress comment #$COMMENT_ID"
 


### PR DESCRIPTION
## Summary
- Fix: `gh issue comment` doesn't support `--json` flag
- Use `gh api` to create comment and get ID directly

## Root Cause
The workflow used `gh issue comment ... --json url --jq '.url'` but `gh issue comment` doesn't have a `--json` flag, causing the "Create progress comment" step to fail.

## Fix
Use `gh api repos/{repo}/issues/{number}/comments -X POST` which returns the comment data including the ID.

Fixes the Code Agent failing on issue #49