### PR TITLE
fix(agents): find PRs by branch pattern instead of author

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -242,13 +242,15 @@ jobs:
       - name: Monitor CI and report results
         if: steps.context.outputs.mode == 'fix' && success()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
+          ISSUE_NUMBER: ${{ steps.context.outputs.number }}
         run: |
-          # Find the most recent PR created by this workflow
-          PR_NUMBER=$(gh pr list --state open --author "@me" --json number,headRefName --jq '.[0].number' 2>/dev/null || echo "")
+          # Find PR by branch pattern fix/{issue_number}-* (Claude creates PRs, not the workflow)
+          PR_NUMBER=$(gh pr list --state open --json number,headRefName \
+            --jq ".[] | select(.headRefName | startswith(\"fix/${ISSUE_NUMBER}-\")) | .number" 2>/dev/null | head -1 || echo "")
 
           if [ -z "$PR_NUMBER" ]; then
-            echo "No open PR found, skipping CI monitoring"
+            echo "No open PR found for issue #${ISSUE_NUMBER}, skipping CI monitoring"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

The CI monitoring step in the Code Agent workflow was failing to find PRs created by Claude because it was using `--author "@me"` which matches the GitHub Actions bot, not Claude.

## Changes

- Changed PR detection from `gh pr list --author "@me"` to finding PRs by branch pattern `fix/{issue_number}-*`
- Updated to use `PAT_WITH_WORKFLOW_ACCESS` for the merge operation

## Root Cause

Claude creates PRs using the PAT, so the author is `app/claude`, not the workflow bot (`@me`). This caused the CI monitoring step to skip the auto-merge.

## Test Plan

- [x] Verified with issue #49 / PR #51 - the original issue that surfaced this bug
- [ ] Next issue should auto-merge correctly