### PR TITLE
fix(workflow): prevent premature issue closure and add E2E debug logs

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -349,11 +349,16 @@ jobs:
 
             ## Step 3: Create/Update PR
             1. Check fifth box [x] and update status to "Creating PR..."
-            2. Commit with message referencing issue: "fix: description\n\nFixes #${{ steps.context.outputs.number }}"
-            3. If PR exists: push to existing branch
-               If new: Push and create PR: gh pr create --title "fix: ..." --body "Fixes #${{ steps.context.outputs.number }}"
-            4. Check sixth box [x] and add PR link to progress comment
-            5. Final status: "✅ PR created! Waiting for CI..."
+            2. **ALWAYS work on a branch, NEVER push directly to main!**
+               - Pushing to main with "Fixes #N" auto-closes issues even if PR hasn't merged
+               - Create branch: git checkout -b fix/${{ steps.context.outputs.number }}-description
+            3. Commit with message: "fix: description\n\nRelates to #${{ steps.context.outputs.number }}"
+               - Use "Relates to #N" in commits (NOT "Fixes #N" - that auto-closes issues!)
+            4. Push to branch and create PR:
+               gh pr create --title "fix: ..." --body "Fixes #${{ steps.context.outputs.number }}"
+               - Put "Fixes #N" only in PR description (closes issue when PR merges)
+            5. Check sixth box [x] and add PR link to progress comment
+            6. Final status: "✅ PR created! Waiting for CI..."
 
             ## Status Label Management
             - If you need human input:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,10 @@ jobs:
         working-directory: backend
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 &
+        run: |
+          # Start backend with logs captured to file for debugging
+          uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 > /tmp/backend.log 2>&1 &
+          echo $! > /tmp/backend.pid
 
       - name: Wait for backend
         run: sleep 5
@@ -160,6 +163,23 @@ jobs:
         working-directory: frontend
         # Only run chromium project - WebKit/iOS projects require additional browser install
         run: npm run test:e2e -- --project=chromium
+
+      - name: Upload E2E test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-debug-logs
+          path: |
+            /tmp/backend.log
+            frontend/test-results/
+            frontend/playwright-report/
+          retention-days: 7
+
+      - name: Print backend logs on failure
+        if: failure()
+        run: |
+          echo "=== Backend Logs ==="
+          cat /tmp/backend.log || echo "No backend logs found"
 
   build-and-push:
     name: Build & Push Docker Images
@@ -445,8 +465,20 @@ jobs:
             [ -z "$ISSUE_NUM" ] && continue
             echo "Checking issue #$ISSUE_NUM..."
 
-            # Get issue state
-            STATE=$(gh issue view $ISSUE_NUM --json state -q .state 2>/dev/null || echo "NOT_FOUND")
+            # Get issue state and labels
+            ISSUE_DATA=$(gh issue view $ISSUE_NUM --json state,labels 2>/dev/null || echo '{"state":"NOT_FOUND","labels":[]}')
+            STATE=$(echo "$ISSUE_DATA" | jq -r '.state')
+            LABELS=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' | tr '\n' ' ')
+
+            # Don't close issues that need human intervention
+            if echo "$LABELS" | grep -q "needs-human"; then
+              echo "Skipping issue #$ISSUE_NUM - has 'needs-human' label (requires human intervention)"
+              continue
+            fi
+            if echo "$LABELS" | grep -q "status:awaiting-human"; then
+              echo "Skipping issue #$ISSUE_NUM - has 'status:awaiting-human' label (waiting for human)"
+              continue
+            fi
 
             if [ "$STATE" = "OPEN" ]; then
               echo "Closing issue #$ISSUE_NUM (deploy successful)"


### PR DESCRIPTION
## Summary

Fixes three workflow issues discovered from issue #84:

### 1. Prevent GitHub Auto-Closing Issues from Commit Messages

**Problem:** Bot pushed commit to main with "Fixes #84", which auto-closed the issue even though PR #85 (the actual fix) hadn't merged.

**Fix:**
- Updated Code Agent prompt to use "Relates to #N" in commit messages
- Only use "Fixes #N" in PR descriptions (so issue closes when PR merges)
- Added explicit warning: NEVER push directly to main

### 2. Safeguard in close-issues Job

**Problem:** CI could close issues that still need human intervention.

**Fix:** Skip closing issues that have:
- `needs-human` label
- `status:awaiting-human` label

### 3. E2E Debugging Improvements

**Problem:** When E2E tests fail, agents can't see backend/frontend server logs to understand WHY.

**Fix:**
- Capture backend logs to `/tmp/backend.log`
- Upload artifacts on failure (backend logs + Playwright test-results + playwright-report)
- Print backend logs in CI output on failure

## Test plan

- [ ] E2E failure uploads artifacts with backend logs
- [ ] close-issues job skips issues with needs-human label
- [ ] Code Agent uses "Relates to #N" in commits, "Fixes #N" only in PR body