### PR TITLE
feat(workflow): add decision-making autonomy to agents

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -259,6 +259,23 @@ jobs:
 
             **CRITICAL: Update progress by EDITING comment #${{ steps.progress.outputs.comment_id }} with checkboxes!**
 
+            ## Decision-Making: BE AUTONOMOUS!
+
+            **Make technical decisions yourself. Don't ask "Should I do A or B?" - DECIDE.**
+
+            Decide autonomously:
+            - Implementation approach (pick the cleanest)
+            - Test strategy (decide what tests are needed)
+            - Timeout values (use reasonable defaults: 30s)
+            - Code style (follow existing patterns)
+
+            Only escalate to human for:
+            - Security decisions (credentials, auth)
+            - Breaking changes (public API changes)
+            - Business logic (product decisions)
+
+            If stuck on a DECISION for 10 minutes, MAKE A CHOICE and document your reasoning.
+
             ## IMPORTANT: Check for Previous Attempts First!
 
             Before starting fresh, check if there's already work done on this issue:

--- a/.github/workflows/principal-engineer.yml
+++ b/.github/workflows/principal-engineer.yml
@@ -131,6 +131,34 @@ jobs:
             - You have broader permissions - can modify workflows, CLAUDE.md, agent prompts
             - Be thorough but autonomous - don't ask for help unless truly stuck
 
+            ## Decision-Making Autonomy (CRITICAL!)
+
+            **You are empowered to make technical decisions.** Don't ask "Should I do A, B, or C?" - DECIDE.
+
+            ### Case Study: Issue #84
+            The Code Agent got stuck and asked: "Should I A) Create new issue, B) Close PR, or C) Merge anyway?"
+            This was WRONG. It should have DECIDED based on engineering judgment.
+
+            ### When to Decide Autonomously (DO THIS):
+            - **Implementation approach** - Pick the cleanest solution
+            - **Test strategy** - Decide what tests are needed
+            - **Timeout/retry values** - Use reasonable defaults (30s timeout, 3 retries)
+            - **Dependency versions** - Pin to latest stable
+            - **Code style** - Follow existing patterns
+            - **PR merge strategy** - Wait for CI, don't merge with failures
+            - **Branch management** - Always use feature branches, never push to main
+
+            ### When to Actually Escalate to Human (RARE):
+            - **Security decisions** - Credentials, auth changes, API keys
+            - **Breaking changes** - Public API changes affecting users
+            - **Business logic** - Product decisions, not technical ones
+            - **Architecture** - Major system redesign (not refactoring)
+            - **Cost implications** - New services, paid APIs
+
+            ### The 10-Minute Rule
+            If you've been stuck on a DECISION (not implementation) for 10 minutes, MAKE A CHOICE.
+            Document your reasoning. A reasonable choice made quickly > perfect choice never made.
+
             ## Investigation Process
 
             ### Step 1: Understand What Happened

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,36 @@ If using branch protection on `main`, ensure:
 2. Update the relevant agent workflow to handle this case autonomously next time
 3. Document the improvement in this file
 
+## Decision-Making Autonomy (CRITICAL)
+
+**Agents are empowered to make technical decisions.** Don't ask "Should I do A, B, or C?" - DECIDE.
+
+### When to Decide Autonomously (DO THIS):
+- **Implementation approach** - Pick the cleanest solution
+- **Test strategy** - Decide what tests are needed
+- **Timeout/retry values** - Use reasonable defaults (30s timeout, 3 retries)
+- **Dependency versions** - Pin to latest stable
+- **Code style** - Follow existing patterns
+- **PR merge strategy** - Wait for CI, don't merge with failures
+- **Branch management** - Always use feature branches, never push to main
+
+### When to Actually Escalate to Human (RARE):
+- **Security decisions** - Credentials, auth changes, API keys
+- **Breaking changes** - Public API changes affecting users
+- **Business logic** - Product decisions, not technical ones
+- **Architecture** - Major system redesign (not refactoring)
+- **Cost implications** - New services, paid APIs
+
+### The 10-Minute Rule
+If you've been stuck on a DECISION (not implementation) for 10 minutes, MAKE A CHOICE.
+Document your reasoning. A reasonable choice made quickly > perfect choice never made.
+
+### Case Study: Issue #84
+The Code Agent got stuck and asked: "Should I A) Create new issue, B) Close PR, or C) Merge anyway?"
+This was WRONG. It should have DECIDED based on engineering judgment. The Principal Engineer agent
+exists to handle cases where the Code Agent gets stuck, taking a holistic approach to fix the
+factory rather than just the symptom.
+
 ## IMPORTANT Rules
 
 - ALWAYS write tests alongside code (unit, integration, E2E)


### PR DESCRIPTION
## Summary

- Adds Decision-Making Autonomy section to Principal Engineer workflow
- Adds Decision-Making section to Code Agent workflow  
- Documents decision-making autonomy guidelines in CLAUDE.md
- References Issue #84 as a case study of why agents should DECIDE, not ask

## Key Changes

### When to Decide Autonomously (agents should do this):
- Implementation approach - pick the cleanest solution
- Test strategy - decide what tests are needed
- Timeout/retry values - use reasonable defaults (30s timeout, 3 retries)
- Dependency versions - pin to latest stable
- Code style - follow existing patterns
- PR merge strategy - wait for CI, don't merge with failures
- Branch management - always use feature branches

### When to Escalate to Human (rare):
- Security decisions - credentials, auth changes, API keys
- Breaking changes - public API changes affecting users
- Business logic - product decisions, not technical ones
- Architecture - major system redesign
- Cost implications - new services, paid APIs

### The 10-Minute Rule
If stuck on a DECISION (not implementation) for 10 minutes, MAKE A CHOICE.
Document your reasoning. A reasonable choice made quickly > perfect choice never made.

## Test Plan
- [ ] Verify workflows still run correctly
- [ ] Confirm new agent prompts include autonomy guidelines
- [ ] Check CLAUDE.md renders properly with new section

Fixes #84