### PR TITLE
feat(workflow): add mandatory log analysis protocol for agents

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -445,6 +445,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: 45
           claude_args: |
+            --model claude-opus-4-5-20250514
             --dangerously-skip-permissions
             --allowedTools "Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(cd:*),Bash(uv:*),Read,Write,Edit,Glob,Grep"
         env:
@@ -546,6 +547,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: 45
           claude_args: |
+            --model claude-opus-4-5-20250514
             --dangerously-skip-permissions
             --allowedTools "Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(cd:*),Bash(uv:*),Read,Write,Edit,Glob,Grep"
         env:
@@ -641,6 +643,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: 45
           claude_args: |
+            --model claude-opus-4-5-20250514
             --dangerously-skip-permissions
             --allowedTools "Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(cd:*),Bash(uv:*),Read,Write,Edit,Glob,Grep"
         env:
@@ -856,7 +859,7 @@ jobs:
 
             gh issue edit "$ISSUE_NUMBER" \
               --remove-label "status:bot-working" \
-              --add-label "needs-human" \
+              --add-label "needs-principal-engineer" \
               --add-label "status:awaiting-human"
           else
             echo "Retrying (attempt $((FAILURE_COUNT + 1)) of 3)..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,9 +470,13 @@ jobs:
             STATE=$(echo "$ISSUE_DATA" | jq -r '.state')
             LABELS=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' | tr '\n' ' ')
 
-            # Don't close issues that need human intervention
+            # Don't close issues that need human or PE intervention
             if echo "$LABELS" | grep -q "needs-human"; then
               echo "Skipping issue #$ISSUE_NUM - has 'needs-human' label (requires human intervention)"
+              continue
+            fi
+            if echo "$LABELS" | grep -q "needs-principal-engineer"; then
+              echo "Skipping issue #$ISSUE_NUM - has 'needs-principal-engineer' label (PE investigating)"
               continue
             fi
             if echo "$LABELS" | grep -q "status:awaiting-human"; then

--- a/.github/workflows/principal-engineer.yml
+++ b/.github/workflows/principal-engineer.yml
@@ -27,10 +27,10 @@ concurrency:
 
 jobs:
   investigate:
-    # Only trigger on needs-human label (escalation from Code Agent)
+    # Only trigger on needs-principal-engineer label (escalation from Code Agent)
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issues' && github.event.label.name == 'needs-human')
+      (github.event_name == 'issues' && github.event.label.name == 'needs-principal-engineer')
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -81,7 +81,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh issue edit ${{ steps.context.outputs.number }} \
-            --remove-label "needs-human" \
+            --remove-label "needs-principal-engineer" \
             --remove-label "status:awaiting-human" \
             --add-label "status:bot-working" 2>/dev/null || true
 
@@ -286,6 +286,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: 55
           claude_args: |
+            --model claude-opus-4-5-20250514
             --dangerously-skip-permissions
             --allowedTools "Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(cd:*),Bash(uv:*),Bash(cat:*),Bash(ls:*),Read,Write,Edit,Glob,Grep"
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ Go to **Settings → Actions → General** and grant these permissions to the Gi
 ### 2. Required Labels
 Create these labels (or run: `gh label create <name> --color <color>`):
 - `ai-ready` (#0E8A16) - Ready for autonomous agent
-- `needs-human` (#D93F0B) - Requires human intervention
+- `needs-principal-engineer` (#7057FF) - Escalated to Principal Engineer (Code Agent stuck)
+- `needs-human` (#D93F0B) - Requires human intervention (PE escalated)
 - `qa-agent` (#0052CC) - QA Agent tracking issues
 - `automation` (#BFDADC) - Automated by agents
 - `ci-failure` (#B60205) - CI failure issues
@@ -295,7 +296,8 @@ Use labels to categorize issues:
 - `bug` - Something isn't working
 - `feature` / `enhancement` - New feature request
 - `ai-ready` - Ready for autonomous agent to pick up
-- `needs-human` - Requires human intervention
+- `needs-principal-engineer` - Escalated to PE (Code Agent stuck)
+- `needs-human` - Requires human intervention (PE escalated)
 - `priority-high`, `priority-medium`, `priority-low`
 
 ## Autonomous Agents
@@ -306,7 +308,7 @@ This repo uses 8 AI-powered GitHub Actions agents. See `.github/workflows/` and 
 |-------|---------|---------|
 | **Triage** | Issue opened | Classifies issues, detects duplicates, adds labels |
 | **Code Agent** | `ai-ready` + `bug`/`enhancement` labels | Diagnoses and fixes issues, creates PRs |
-| **Principal Engineer** | `needs-human` label (escalation) | Holistic debugging, fixes factory not just symptoms |
+| **Principal Engineer** | `needs-principal-engineer` label | Holistic debugging, fixes factory not just symptoms |
 | **QA** | Nightly 2am UTC | Test quality improvement with daily focus rotation |
 | **Release Eng** | Daily 3am UTC | Security audits, dependency updates, CI optimization |
 | **DevOps** | Every 6 hours | Health checks, incident response |
@@ -315,18 +317,18 @@ This repo uses 8 AI-powered GitHub Actions agents. See `.github/workflows/` and 
 
 ### Escalation Flow
 
-When Code Agent gets stuck (timeout, 3x CI failure), it adds `needs-human` label which triggers the **Principal Engineer**:
+When Code Agent gets stuck (timeout, 3x CI failure), it adds `needs-principal-engineer` label which triggers the **Principal Engineer**:
 
 ```
-Code Agent stuck → adds needs-human → Principal Engineer investigates
-                                    ↓
-                    Analyzes root cause (code? infra? workflow?)
-                                    ↓
-                    Downloads E2E artifacts, reads backend logs
-                                    ↓
-                    Fixes issue AND updates factory to prevent recurrence
-                                    ↓
-                    Only escalates to human if truly stuck
+Code Agent stuck → adds needs-principal-engineer → Principal Engineer investigates
+                                                           ↓
+                                       Analyzes root cause (code? infra? workflow?)
+                                                           ↓
+                                       Downloads E2E artifacts, reads backend logs
+                                                           ↓
+                                       Fixes issue AND updates factory to prevent recurrence
+                                                           ↓
+                                       If truly stuck → adds needs-human → Human reviews
 ```
 
 **Principal Engineer responsibilities:**


### PR DESCRIPTION
## Summary

Agents were attempting fixes without analyzing workflow/server logs, leading to repeated failures on the same issues. This adds explicit **Log Analysis Protocol** sections to ensure agents READ THE ACTUAL ERRORS before implementing fixes.

## Changes

### Added to all agent modes (fix, continue, respond):
- **Step 1**: Check issue comments for "❌ CI Failed" - contains actual failure logs
- **Step 2**: Get workflow logs via `gh run view <RUN_ID> --log-failed`
- **Step 3**: Download E2E artifacts (backend.log, Playwright reports)
- **Step 4**: Document findings in progress comment BEFORE implementing

### Updated CLAUDE.md:
- Added "Log Analysis Protocol (MANDATORY for agents)" section
- Agents must document what logs showed before attempting any fix

## Why This Matters

Previously, when CI failed:
1. CI-monitor posts failure logs in issue comment
2. Triggers retry
3. Agent just guesses at fix without reading the logs
4. Fails again...repeat

Now:
1. CI-monitor posts failure logs in issue comment
2. Triggers retry
3. **Agent reads "❌ CI Failed" comment and analyzes logs**
4. **Agent documents findings before implementing**
5. Fix is based on actual errors, not guessing

## Test Plan
- [ ] Verify workflow runs successfully
- [ ] Manually verify agents include log analysis steps

Fixes #84