### PR TITLE
fix(devops): remove invalid secrets reference in if conditions

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -173,7 +173,6 @@ jobs:
 
       - name: Collect Railway logs
         id: railway_logs
-        if: ${{ secrets.RAILWAY_TOKEN != '' }}
         continue-on-error: true
         run: |
           # Get last 50 lines of logs from each service
@@ -259,7 +258,7 @@ jobs:
           echo "$HOME/.railway/bin" >> $GITHUB_PATH
 
       - name: Link Railway project
-        if: ${{ secrets.RAILWAY_TOKEN != '' }}
+        continue-on-error: true
         run: |
           # Railway CLI auto-detects project from RAILWAY_TOKEN in CI mode
           railway status || echo "Railway not linked - some features may be limited"


### PR DESCRIPTION
GitHub Actions doesn't allow referencing secrets in 'if' conditions. Changed to use continue-on-error instead.

Relates to DevOps agent testing