### PR TITLE
fix(ci): correct Claude Code install syntax

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -252,12 +252,19 @@ jobs:
           echo "comment_id=$COMMENT_ID" >> $GITHUB_OUTPUT
           echo "Created progress comment #$COMMENT_ID"
 
-      # Pre-install Claude Code with --force to avoid race condition lock issues
+      # Pre-install Claude Code to avoid race condition lock issues
       - name: Pre-install Claude Code
         run: |
-          echo "Pre-installing Claude Code with --force flag..."
-          curl -fsSL https://claude.ai/install.sh | bash -s -- --force 2.0.74
+          # Check if claude is already installed
+          if command -v claude &> /dev/null; then
+            echo "Claude Code already installed: $(claude --version 2>/dev/null || echo 'unknown version')"
+          else
+            echo "Installing Claude Code..."
+            curl -fsSL https://claude.ai/install.sh | bash -s -- stable
+          fi
+          # Add to PATH regardless
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.claude/bin" >> $GITHUB_PATH
 
       - name: Run Claude (fix mode)
         if: steps.context.outputs.mode == 'fix'


### PR DESCRIPTION
## Summary
- Fixed the Claude Code install syntax in bug-fix.yml
- The install script doesn't support `--force` flag - it only accepts `[stable|latest|VERSION]`
- Added check to skip installation if already installed
- Added both possible PATH locations for Claude

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Code Agent should now run successfully on issue #111

Relates to #111