### PR TITLE
fix(ci): include respond mode in CI monitor for auto-retry

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -664,7 +664,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
 
       - name: Monitor CI and report results
-        if: (steps.context.outputs.mode == 'fix' || steps.context.outputs.mode == 'continue') && success()
+        # Also include 'respond' mode since it can create PRs too
+        if: (steps.context.outputs.mode == 'fix' || steps.context.outputs.mode == 'continue' || steps.context.outputs.mode == 'respond') && success()
         id: ci-monitor
         env:
           # IMPORTANT: Use GITHUB_TOKEN for comments to avoid triggering issue_comment events


### PR DESCRIPTION
## Summary
**Root cause of issue #120 not auto-retrying:** The CI monitor step only ran for `fix` and `continue` modes, but `respond` mode can also create PRs.

When PR #121 was created via a comment response, the CI monitor was **skipped**, so no auto-retry was triggered when CI failed.

**Fix:** Include `respond` mode in the CI monitor condition.

## Test plan
- [x] Workflow syntax valid
- [ ] Next time a PR is created via comment, CI monitor should run and auto-retry on failure

Relates to #120