### PR TITLE
fix(ci): detect new files in template sync

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -81,8 +81,14 @@ jobs:
         id: changes
         working-directory: template
         run: |
-          git diff --stat
-          if git diff --quiet; then
+          # Stage all changes first (including new files)
+          git add -A
+
+          # Show what would be committed
+          git diff --cached --stat
+
+          # Check if there are any staged changes
+          if git diff --cached --quiet; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
             echo "No changes to sync"
           else
@@ -97,7 +103,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add -A
+          # Files already staged in "Check for changes" step
           git commit -m "sync: workflow improvements from upstream
 
           Auto-synced and generalized from upstream project


### PR DESCRIPTION
## Summary

- Template sync was failing to detect new files (like `ci-watcher.yml`) because `git diff --quiet` only checks tracked files
- New files that don't exist in the template repo were silently ignored
- Fixed by staging all changes first with `git add -A` then checking staged changes with `git diff --cached --quiet`

## Test plan

- [ ] Push this PR and verify it syncs ci-watcher.yml to template repo
- [ ] Check template repo has ci-watcher.yml after workflow runs