### PR TITLE
feat(devops): close conflicting PRs for Code Agent to recreate

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -662,12 +662,16 @@ jobs:
                   git rebase --abort 2>/dev/null || true
                 fi
               else
-                # Rebase failed - conflicts need manual resolution
-                echo "   ⚠️ Auto-rebase failed for PR #$PR_NUM - conflicts need manual resolution"
+                # Rebase failed - close PR so Code Agent can recreate fresh
+                echo "   ⚠️ Auto-rebase failed for PR #$PR_NUM - closing for Code Agent to recreate"
                 git rebase --abort 2>/dev/null || true
 
-                # Comment on PR about the conflict
-                gh pr comment "$PR_NUM" --repo "$GITHUB_REPOSITORY" --body "Auto-rebase failed - conflicts require manual resolution. Run: git fetch origin && git checkout $PR_BRANCH && git rebase origin/main" || echo "   (Could not comment on PR)"
+                # Close the PR with explanation - Code Agent will recreate from the still-open issue
+                gh pr close "$PR_NUM" --repo "$GITHUB_REPOSITORY" --comment "Closing this PR due to merge conflicts that require intelligent resolution. The related issue still has the ai-ready label, so the Code Agent will automatically create a fresh PR from the current main branch." || echo "   (Could not close PR)"
+
+                # Delete the stale branch
+                git push origin --delete "$PR_BRANCH" 2>/dev/null || echo "   (Could not delete branch)"
+
                 FAILED_COUNT=$((FAILED_COUNT + 1))
               fi
 


### PR DESCRIPTION
## Summary

Closes the factory gap for handling merge conflicts that can't be auto-rebased.

**When auto-rebase fails:**
1. Close the PR with explanation
2. Delete the stale branch  
3. The related issue keeps `ai-ready` label
4. Code Agent picks up the issue and creates fresh PR from main

## Test Plan

- PR #129 has conflicts that can't be auto-resolved
- After merge, auto-rebase will close PR #129
- Issue #127 still has `ai-ready`, so Code Agent will recreate the PR fresh

Relates to #127