### PR TITLE
fix(factory): Code Agent label order race condition and issue auto-close

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -101,18 +101,21 @@ jobs:
 
   fix:
     # Triggers on:
-    # 1. ai-ready label + (bug OR enhancement)
-    # 2. Comment containing @claude on an issue with ai-ready label
-    # 3. ANY comment on an issue with status:awaiting-bot label (human responded)
-    # 4. Manual workflow dispatch
+    # 1. ai-ready label added AND issue already has (bug OR enhancement)
+    # 2. bug/enhancement label added AND issue already has ai-ready
+    # 3. Comment containing @claude on an issue with ai-ready label
+    # 4. ANY comment on an issue with status:awaiting-bot label (human responded)
+    # 5. Manual workflow dispatch
     # SKIP if: needs-human label is present (escalated, requires human intervention)
     if: |
       !contains(github.event.issue.labels.*.name, 'needs-human') &&
       (github.event_name == 'workflow_dispatch' ||
        (github.event_name == 'issues' &&
-        github.event.label.name == 'ai-ready' &&
-        (contains(github.event.issue.labels.*.name, 'bug') ||
-         contains(github.event.issue.labels.*.name, 'enhancement'))) ||
+        ((github.event.label.name == 'ai-ready' &&
+          (contains(github.event.issue.labels.*.name, 'bug') ||
+           contains(github.event.issue.labels.*.name, 'enhancement'))) ||
+         ((github.event.label.name == 'bug' || github.event.label.name == 'enhancement') &&
+          contains(github.event.issue.labels.*.name, 'ai-ready')))) ||
        (github.event_name == 'issue_comment' &&
         !github.event.issue.pull_request &&
         (contains(github.event.comment.body, '@claude') ||
@@ -909,6 +912,11 @@ jobs:
           🚀 **Deploying to production...** The changes will be live shortly.
 
           cc @${ISSUE_AUTHOR}"
+
+                  # Explicitly close issue - GitHub's auto-close doesn't work when merging via API/CLI
+                  echo "Closing issue #${{ steps.context.outputs.number }}..."
+                  gh issue close ${{ steps.context.outputs.number }} \
+                    --comment "Closed by PR #${PR_NUMBER}" 2>/dev/null || echo "Issue already closed or not found"
 
                   # Trigger CI/CD workflow via repository_dispatch since GITHUB_TOKEN merges don't trigger push events
                   echo "Triggering deploy via repository_dispatch..."

--- a/.github/workflows/ci-watcher.yml
+++ b/.github/workflows/ci-watcher.yml
@@ -222,6 +222,16 @@ jobs:
 
           All checks passed. PR #$PR_NUMBER has been automatically merged.
           🚀 **Deploying to production...**"
+
+              # Explicitly close issues referenced with "Fixes #N" or "Closes #N"
+              # GitHub's auto-close doesn't work when merging via API/CLI
+              PR_BODY=$(gh pr view "$PR_NUMBER" --repo ${{ github.repository }} --json body --jq '.body' 2>/dev/null || echo "")
+              FIXED_ISSUES=$(echo "$PR_BODY" | grep -oE '(Fixes|Closes|Resolves) #[0-9]+' | grep -oE '[0-9]+' || echo "")
+              for FIXED_ISSUE in $FIXED_ISSUES; do
+                echo "Closing related issue #$FIXED_ISSUE..."
+                gh issue close "$FIXED_ISSUE" --repo ${{ github.repository }} \
+                  --comment "Closed by PR #$PR_NUMBER" 2>/dev/null || echo "Failed to close #$FIXED_ISSUE"
+              done
             fi
           else
             STATUS_MSG="## ❌ CI Failed


### PR DESCRIPTION
## Summary

Two factory bugs fixed:

### Bug 1: Code Agent not triggered due to label order race condition

**Problem:** Issue #137 had `ai-ready` + `bug` labels but Code Agent never ran.

**Root Cause:** Labels were added in rapid succession:
- `20:30:44Z` - `ai-ready` added → workflow checks "has bug?" → NO (not yet!) → **SKIP**
- `20:30:55Z` - `bug` added → workflow checks "is this ai-ready event?" → NO → **SKIP**

**Fix:** Trigger Code Agent when EITHER:
- `ai-ready` is added AND issue already has `bug`/`enhancement`, OR
- `bug`/`enhancement` is added AND issue already has `ai-ready`

### Bug 2: Issues not auto-closed when PRs merge via API

**Problem:** Issue #127 stayed open even though PR #152 (with `Fixes #127`) was merged.

**Root Cause:** GitHub's auto-close feature doesn't work when merging via `gh pr merge` with `GITHUB_TOKEN`.

**Fix:** Explicitly close referenced issues after successful merge in both:
- `ci-watcher.yml`
- `bug-fix.yml`

## Test plan

- [x] Label trigger condition updated in bug-fix.yml
- [x] Auto-close logic added to ci-watcher.yml (after merge)
- [x] Auto-close logic added to bug-fix.yml (after merge)
- [ ] Trigger Code Agent for #137 after merge to verify fix
- [ ] Create factory-improvement issue documenting these fixes

Relates to #137