### PR TITLE
fix(factory): preserve activity log when updating progress comment

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -806,7 +806,8 @@ jobs:
                   EXISTING_BODY=$(gh api repos/${{ github.repository }}/issues/comments/$PROGRESS_COMMENT_ID --jq '.body' 2>/dev/null || echo "")
 
                   # Extract existing activity log entries (everything between the table header and ---)
-                  EXISTING_LOG=$(echo "$EXISTING_BODY" | sed -n '/| Time | Event |/,/^---/p' | head -n -1 || echo "")
+                  # Note: Pattern handles optional leading whitespace from YAML heredoc formatting
+                  EXISTING_LOG=$(echo "$EXISTING_BODY" | sed -n '/| Time | Event |/,/^[[:space:]]*---/p' | head -n -1 || echo "")
 
                   gh api repos/${{ github.repository }}/issues/comments/$PROGRESS_COMMENT_ID \
                     -X PATCH -f body="## 🤖 Code Agent Progress
@@ -876,7 +877,8 @@ jobs:
                   # Update progress comment with success, preserving activity log
                   if [ -n "$PROGRESS_COMMENT_ID" ]; then
                     EXISTING_BODY=$(gh api repos/${{ github.repository }}/issues/comments/$PROGRESS_COMMENT_ID --jq '.body' 2>/dev/null || echo "")
-                    EXISTING_LOG=$(echo "$EXISTING_BODY" | sed -n '/| Time | Event |/,/^---/p' | head -n -1 || echo "")
+                    # Note: Pattern handles optional leading whitespace from YAML heredoc formatting
+                    EXISTING_LOG=$(echo "$EXISTING_BODY" | sed -n '/| Time | Event |/,/^[[:space:]]*---/p' | head -n -1 || echo "")
 
                     # Try to extract summary section if it exists
                     SUMMARY_SECTION=$(echo "$EXISTING_BODY" | sed -n '/## 🔍 Summary/,$p' || echo "")


### PR DESCRIPTION
## Summary

Fixes a bug where the activity log entries were being lost when updating the progress comment.

## Problem

Issue #137's progress comment only showed the final entry:
```
| 2026-01-04 23:51 UTC | ✅ CI passed, PR merged! |
```

All intermediate entries (starting analysis, implementing fix, etc.) were lost.

## Root Cause

The sed pattern for extracting existing activity log entries used `^---`:
```bash
EXISTING_LOG=$(echo "$EXISTING_BODY" | sed -n '/| Time | Event |/,/^---/p' | head -n -1)
```

However, the YAML heredocs in the workflow have leading whitespace (10 spaces) that becomes part of the stored content:
```yaml
          ---
          ## 📋 Activity Log
```

So the actual stored content is `          ---` (with spaces), but `^---` expects `---` at the **start of line**. Pattern never matched → EXISTING_LOG was empty → only new entry was written.

## Fix

Changed pattern to handle optional leading whitespace:
```bash
EXISTING_LOG=$(echo "$EXISTING_BODY" | sed -n '/| Time | Event |/,/^[[:space:]]*---/p' | head -n -1)
```

Updated in both locations:
- Line 810 (CI failure update)
- Line 881 (merge success update)

## Test plan

- [ ] Next Code Agent run should preserve full activity log
- [ ] Verify intermediate steps appear in final progress comment

Relates to #137