### PR TITLE
feat(factory): add activity log quality check after Code Agent runs

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -715,6 +715,37 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
           GITHUB_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
 
+      - name: Check activity log quality
+        if: (steps.context.outputs.mode == 'fix' || steps.context.outputs.mode == 'continue') && success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROGRESS_COMMENT_ID: ${{ steps.progress.outputs.comment_id || steps.continue_progress.outputs.comment_id }}
+        run: |
+          # Quality check: Did Claude Code update the activity log with meaningful entries?
+          if [ -z "$PROGRESS_COMMENT_ID" ]; then
+            echo "⚠️ No progress comment ID found, skipping quality check"
+            exit 0
+          fi
+
+          COMMENT_BODY=$(gh api repos/${{ github.repository }}/issues/comments/$PROGRESS_COMMENT_ID --jq '.body' 2>/dev/null || echo "")
+
+          # Count activity log entries (lines starting with |, excluding header row)
+          LOG_ENTRIES=$(echo "$COMMENT_BODY" | grep -E '^\s*\|.*\d{4}-\d{2}-\d{2}' | wc -l || echo "0")
+
+          echo "Activity log entries found: $LOG_ENTRIES"
+
+          if [ "$LOG_ENTRIES" -le 1 ]; then
+            echo "⚠️ QUALITY WARNING: Activity log has only $LOG_ENTRIES entry/entries"
+            echo "Claude Code did not update the progress comment with intermediate steps."
+            echo "The activity log should show: analysis, root cause, implementation steps, test results"
+            echo ""
+            echo "This is a known issue - Claude Code receives instructions to update the activity log"
+            echo "but often prioritizes completing the work over status updates."
+            # Future: Could escalate to PE or add a label for tracking
+          else
+            echo "✅ Activity log has $LOG_ENTRIES entries - good progress tracking!"
+          fi
+
       - name: Monitor CI and report results
         # Also include 'respond' mode since it can create PRs too
         if: (steps.context.outputs.mode == 'fix' || steps.context.outputs.mode == 'continue' || steps.context.outputs.mode == 'respond') && success()


### PR DESCRIPTION
## Summary

Adds a quality gate step that checks if Claude Code updated the progress comment with meaningful activity log entries.

## The Factory Gap

Currently there's a blind spot:
- Code Agent **succeeds** (completes work, creates PR)
- But doesn't document what it did in the activity log
- **No agent catches this** because:
  - PE only triggers when Code Agent gets **stuck**
  - QA Agent focuses on test coverage
  - DevOps checks for stuck PRs, not quality

Example: Issue #162 was fixed successfully, but the activity log only shows:
```
| 2026-01-05 01:02 UTC | ✅ CI passed, PR merged! |
```
No entries for: analyzing, finding root cause, implementing, testing...

## What This PR Does

Adds a "Check activity log quality" step after Claude Code runs that:
1. Reads the progress comment
2. Counts activity log entries with timestamps
3. Logs a warning if ≤1 entry found

Currently just warns - doesn't block. Future iterations could:
- Escalate to PE when logs are empty
- Add a `low-visibility` label for tracking
- Retry with emphasis on status updates

## Root Cause (for the record)

Claude Code has **detailed instructions** to update the activity log (bug-fix.yml lines 402-470) but often prioritizes completing the work over status updates. This is a behavior pattern we need to monitor.

## Test plan

- [x] Quality check step added
- [ ] Next Code Agent run will log quality status
- [ ] Create factory-improvement issue documenting this gap