### PR TITLE
fix(factory): repository_dispatch JSON and CI Watcher branch patterns

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -961,10 +961,11 @@ jobs:
 
                   # Trigger CI/CD workflow via repository_dispatch since GITHUB_TOKEN merges don't trigger push events
                   echo "Triggering deploy via repository_dispatch..."
+                  # Note: Use -F (not -f) for client_payload so it's passed as JSON object, not string
                   gh api repos/${{ github.repository }}/dispatches \
                     -X POST \
                     -f event_type=deploy-after-merge \
-                    -f client_payload='{"pr_number": "'${PR_NUMBER}'", "issue_number": "${{ steps.context.outputs.number }}"}' || echo "Warning: Failed to trigger deploy dispatch"
+                    -F client_payload='{"pr_number":"'"${PR_NUMBER}"'","issue_number":"${{ steps.context.outputs.number }}"}' || echo "Warning: Failed to trigger deploy dispatch"
                 else
                   gh issue comment ${{ steps.context.outputs.number }} --body "## ✅ CI Passed
 

--- a/.github/workflows/ci-watcher.yml
+++ b/.github/workflows/ci-watcher.yml
@@ -31,16 +31,24 @@ jobs:
           echo "Branch: $HEAD_BRANCH"
           echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
 
-          # Extract issue number from branch name (fix/123-desc or feat/123-desc)
+          # Extract issue number from branch name
+          # Patterns supported:
+          #   fix/123-desc, feat/123-desc (Code Agent)
+          #   claude/qa-*-123, claude/*-123 (QA Agent and other Claude branches)
+          ISSUE_NUMBER=""
           if [[ "$HEAD_BRANCH" =~ ^(fix|feat)/([0-9]+) ]]; then
             ISSUE_NUMBER="${BASH_REMATCH[2]}"
-            echo "Found issue number: $ISSUE_NUMBER"
-            echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+            echo "Found issue number from fix/feat pattern: $ISSUE_NUMBER"
+          elif [[ "$HEAD_BRANCH" =~ -([0-9]+)$ ]]; then
+            # Issue number at end of branch name (e.g., claude/qa-coverage-sprint-169)
+            ISSUE_NUMBER="${BASH_REMATCH[1]}"
+            echo "Found issue number from branch suffix: $ISSUE_NUMBER"
           else
-            echo "Branch doesn't match issue pattern, skipping"
+            echo "Branch doesn't match any issue pattern, skipping"
             echo "issue_number=" >> $GITHUB_OUTPUT
             exit 0
           fi
+          echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
 
           # Get PR number
           PR_NUMBER=$(gh pr list --repo ${{ github.repository }} \


### PR DESCRIPTION
## Summary

Fixes two factory bugs discovered when investigating issues #162 and #170.

### Bug 1: Deployments not triggered after merge (Issue #162)

**Symptom:** PR #163 merged but settings feature never deployed to production.

**Root Cause:** The `repository_dispatch` API call used `-f client_payload='...'` which passes the JSON as a **string**. GitHub API expects `client_payload` to be a JSON **object**.

```bash
# Before (broken)
gh api .../dispatches -f client_payload='{"pr_number": "123"}'
# GitHub receives: client_payload = '{"pr_number": "123"}' (string!)

# After (fixed) 
gh api .../dispatches -F client_payload='{"pr_number": "123"}'
# GitHub receives: client_payload = {"pr_number": "123"} (object!)
```

### Bug 2: QA Agent PRs not monitored by CI Watcher (PR #170)

**Symptom:** PR #170 from QA Agent failing for 30+ minutes with no one noticing.

**Root Cause:** CI Watcher only matched `fix/NNN-*` and `feat/NNN-*` branches. QA Agent uses `claude/qa-*-NNN` pattern.

**Fix:** Added pattern to match issue number at end of branch name:
```bash
elif [[ "$HEAD_BRANCH" =~ -([0-9]+)$ ]]; then
  ISSUE_NUMBER="${BASH_REMATCH[1]}"
fi
```

## Why Code Agent Didn't Fix This

The Code Agent investigating #162 found the bug but then said "I don't have permission" and asked for human help. **This is wrong** - Code Agent DOES have `PAT_WITH_WORKFLOW_ACCESS`. This is a factory issue where Code Agent is being too timid.

## Test plan

- [x] Triggered manual deployment for #162
- [x] Fixed -f to -F for client_payload
- [x] Added branch suffix pattern to CI Watcher
- [ ] Next QA Agent PR will be monitored by CI Watcher

Relates to #162, #169