### PR TITLE
fix(factory): enforce formatting before commits in all agents

### DIFF
--- a/.claude/agents/bug-fixer.md
+++ b/.claude/agents/bug-fixer.md
@@ -11,6 +11,11 @@ tools: Read, Write, Edit, Bash, Glob, Grep
 3. Create branch: `fix/<issue>-<desc>`
 4. Implement minimal fix
 5. Add regression test
-6. Run: `npm run lint && npm run typecheck && npm run test`
-7. Create PR: `gh pr create`
-8. If CI fails 3x, escalate to @jeremy
+6. **CRITICAL: Format and lint BEFORE committing:**
+   - Backend: `cd backend && uv run ruff format . && uv run ruff check . --fix`
+   - Frontend: `cd frontend && npm run format && npm run lint -- --fix`
+7. Run full quality gates:
+   - Backend: `cd backend && uv run pytest && uv run mypy .`
+   - Frontend: `cd frontend && npm run lint && npm run typecheck && npm test`
+8. Create PR: `gh pr create`
+9. If CI fails 3x, escalate to @jeremy

--- a/.claude/agents/qa-improver.md
+++ b/.claude/agents/qa-improver.md
@@ -90,6 +90,20 @@ After each session, create a PR with:
 4. Any flaky tests identified and fixed
 5. Recommendations for areas needing human attention
 
+## CRITICAL: Pre-Commit Requirements
+
+**ALWAYS run formatters and linters BEFORE committing ANY code!**
+
+```bash
+# Backend (REQUIRED)
+cd backend && uv run ruff format . && uv run ruff check . --fix
+
+# Frontend (if any frontend files changed)
+cd frontend && npm run format && npm run lint -- --fix
+```
+
+CI will fail if code is not properly formatted. Never skip this step.
+
 **IMPORTANT**: The TEST_PLAN.md file must be kept in sync with the actual tests. Every new test needs a corresponding entry in TEST_PLAN.md.
 
 ## Escalation

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -199,10 +199,20 @@ jobs:
             3. Update TEST_PLAN.md with new test descriptions
             4. **EDIT ISSUE**: Check "📄 Update TEST_PLAN.md" box
 
-            ### Step 5: Create PR and Final Update
-            1. Create PR: `gh pr create --title "test: [description]" --body "Relates to #${{ steps.create-issue.outputs.issue_number }}"`
-            2. **EDIT ISSUE**: Check "🚀 Create PR" box, update "Final Results" with coverage and PR link
-            3. Close the issue: `gh issue close ${{ steps.create-issue.outputs.issue_number }}`
+            ### Step 5: Format, Lint, Create PR
+            **CRITICAL: Run formatters and linters BEFORE committing!**
+            1. Format and lint backend code:
+               ```bash
+               cd backend && uv run ruff format . && uv run ruff check . --fix
+               ```
+            2. Format and lint frontend code (if changed):
+               ```bash
+               cd frontend && npm run format && npm run lint -- --fix
+               ```
+            3. Commit all changes (including format fixes)
+            4. Create PR: `gh pr create --title "test: [description]" --body "Relates to #${{ steps.create-issue.outputs.issue_number }}"`
+            5. **EDIT ISSUE**: Check "🚀 Create PR" box, update "Final Results" with coverage and PR link
+            6. Close the issue: `gh issue close ${{ steps.create-issue.outputs.issue_number }}`
 
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |


### PR DESCRIPTION
## Summary

The QA Agent created PR #170 without running formatters first, causing CI to fail on format check. This adds explicit formatting instructions to all agent workflows and definitions to prevent future occurrences.

## Changes

- **qa.yml**: Add Step 5 instructions to run `ruff format` and `ruff check` before committing
- **qa-improver.md**: Add "CRITICAL: Pre-Commit Requirements" section with explicit formatting commands
- **bug-fixer.md**: Add explicit format/lint commands for both backend and frontend code

## Test Plan

- [ ] QA Agent runs (nightly) should now include formatting step
- [ ] Code Agent runs should follow explicit formatting instructions
- [ ] No more CI failures due to formatting issues

## Factory Improvement

This prevents a class of CI failures where agents write code but forget to run formatters before committing.