### PR TITLE
fix(factory): stop Code Agent from falsely claiming permission issues

### DIFF
--- a/.claude/agents/bug-fixer.md
+++ b/.claude/agents/bug-fixer.md
@@ -6,6 +6,15 @@ tools: Read, Write, Edit, Bash, Glob, Grep
 
 # Bug Fixer Agent
 
+## You Have Full Permissions - Use Them!
+
+You have `PAT_WITH_WORKFLOW_ACCESS` granting FULL repository access:
+- ✅ Can trigger workflows, merge PRs, modify workflow files
+- ✅ Can push to any branch, create/close issues and PRs
+- **DO NOT claim "permission denied" without actually trying the command first!**
+
+## Steps
+
 1. Read CLAUDE.md for quality gates
 2. Diagnose before coding
 3. Create branch: `fix/<issue>-<desc>`

--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -320,6 +320,20 @@ jobs:
 
             If stuck on a DECISION for 10 minutes, MAKE A CHOICE and document your reasoning.
 
+            ## 🔑 YOU HAVE FULL PERMISSIONS - USE THEM!
+
+            **You have PAT_WITH_WORKFLOW_ACCESS which grants FULL repository permissions:**
+            - ✅ Can trigger workflows via `gh workflow run` or `repository_dispatch`
+            - ✅ Can merge PRs via `gh pr merge`
+            - ✅ Can modify ANY file including `.github/workflows/`
+            - ✅ Can create/close issues and PRs
+            - ✅ Can push to any branch
+
+            **DO NOT claim you "don't have permission" without actually trying!**
+            - If you think you can't do something, TRY IT FIRST
+            - Only escalate if the command actually fails with a permission error
+            - Being overly conservative wastes human time on things you CAN do
+
             ## 📋 LOG ANALYSIS PROTOCOL (MANDATORY!)
 
             **BEFORE implementing ANY fix, you MUST analyze logs.** Don't guess - READ THE ACTUAL ERRORS!


### PR DESCRIPTION
## Summary

The Code Agent repeatedly claims it "doesn't have permission" when it actually has full access via `PAT_WITH_WORKFLOW_ACCESS`. This wastes human time on issues the agent can handle autonomously.

**Examples of this pattern:**
- Issue #162: Agent said "I don't have permission to trigger workflows" when it does
- Various other issues where agent escalated unnecessarily

## Changes

Added explicit "YOU HAVE FULL PERMISSIONS" guidance to:

1. **`.github/workflows/bug-fix.yml`** - New section in the prompt:
   - Lists what agent CAN do (trigger workflows, merge PRs, modify workflow files)
   - Explicitly tells agent to TRY commands before claiming permission denied
   - Warns that being overly conservative wastes human time

2. **`.claude/agents/bug-fixer.md`** - Same guidance at top of agent definition

## Factory Improvement

This fixes a recurring factory bug where the agent's conservative behavior causes unnecessary human escalations. The agent should:
- TRY actions first
- Only escalate if the command actually fails with a permission error
- Not pre-emptively give up on things it can do