### PR TITLE
fix(factory): improve @claude mention detection in issue comments

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -119,6 +119,8 @@ jobs:
        (github.event_name == 'issue_comment' &&
         !github.event.issue.pull_request &&
         (contains(github.event.comment.body, '@claude') ||
+         contains(github.event.comment.body, '@Claude') ||
+         contains(github.event.comment.body, 'claude') ||
          contains(github.event.issue.labels.*.name, 'status:awaiting-bot'))))
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## Summary

The issue_comment trigger was failing to detect `@claude` mentions in comments, causing the Code Agent to not respond when users @mentioned it.

## Root Cause

The `contains(github.event.comment.body, '@claude')` condition wasn't matching. Unclear if this is a GitHub Actions expression bug with the `@` symbol or case sensitivity issue.

## Fix

Added multiple variations to ensure detection works:
- `@claude` (original)
- `@Claude` (capital C)
- `claude` (without @, as fallback)

## Test

- Issue #175 had a comment with `@claude` that didn't trigger
- After adding `status:awaiting-bot` label, the trigger worked
- This confirms the label-based trigger works but `@claude` detection doesn't