### PR TITLE
feat(factory): enable inter-agent diagnostics via @devops mentions

### DIFF
--- a/.claude/agents/bug-fixer.md
+++ b/.claude/agents/bug-fixer.md
@@ -13,10 +13,17 @@ You have `PAT_WITH_WORKFLOW_ACCESS` granting FULL repository access:
 - ✅ Can push to any branch, create/close issues and PRs
 - **DO NOT claim "permission denied" without actually trying the command first!**
 
+## Production Diagnostics
+
+Need to check production data? Ask the DevOps Agent:
+- Post `@devops please check <what you need>` on the issue
+- DevOps will query production and post results
+- Example: `@devops check user logs` or `@devops check database status`
+
 ## Steps
 
 1. Read CLAUDE.md for quality gates
-2. Diagnose before coding
+2. Diagnose before coding (use @devops for production data if needed)
 3. Create branch: `fix/<issue>-<desc>`
 4. Implement minimal fix
 5. Add regression test

--- a/.claude/agents/devops-sre.md
+++ b/.claude/agents/devops-sre.md
@@ -8,7 +8,16 @@ tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
 
 Health check: `curl https://diningphilosophers.ai/api/health`
 
-Incident severity:
+## Inter-Agent Diagnostics
+
+Other agents can request production diagnostics by commenting `@devops` on issues.
+This agent will:
+1. Query Railway logs and service status
+2. Check relevant production data
+3. Post results back to the issue
+
+## Incident Severity
+
 - SEV1: Production down → fix or escalate immediately
 - SEV2: Major feature broken → fix within 15min
 - SEV3: Minor issue → create issue

--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -336,6 +336,24 @@ jobs:
             - Only escalate if the command actually fails with a permission error
             - Being overly conservative wastes human time on things you CAN do
 
+            ## 🔍 PRODUCTION DIAGNOSTICS - Ask DevOps Agent!
+
+            **Need to check production data to diagnose an issue?** You can request help from the DevOps Agent:
+
+            1. Post a comment on the issue: `@devops please check <what you need>`
+            2. DevOps Agent will query production and post results
+            3. Wait for the response before continuing
+
+            **Example requests:**
+            - `@devops check user logs for authentication errors`
+            - `@devops check database connection status`
+            - `@devops check recent backend logs`
+
+            This is useful when you need to verify:
+            - If a user exists or has certain data in production
+            - If an API is returning expected responses
+            - What errors are occurring in production logs
+
             ## 📋 LOG ANALYSIS PROTOCOL (MANDATORY!)
 
             **BEFORE implementing ANY fix, you MUST analyze logs.** Don't guess - READ THE ACTUAL ERRORS!

--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -3,6 +3,8 @@ name: DevOps Agent
 on:
   push:
     branches: [main]
+  issue_comment:
+    types: [created]
   schedule:
     # Run health checks every 5 minutes
     - cron: '*/5 * * * *'
@@ -50,6 +52,104 @@ env:
   FAILURE_THRESHOLD: 2
 
 jobs:
+  # ===========================================
+  # DIAGNOSTIC REQUESTS (triggered by @devops mentions)
+  # ===========================================
+  diagnostic-request:
+    if: |
+      github.event_name == 'issue_comment' &&
+      !github.event.issue.pull_request &&
+      (contains(github.event.comment.body, '@devops') ||
+       contains(github.event.comment.body, '@DevOps'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Acknowledge request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} --body "## 🔧 DevOps Agent Responding
+
+          **Request:** Checking production data...
+          **Workflow:** [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          Please wait while I gather the requested information."
+
+      - name: Install Railway CLI
+        run: |
+          if curl -fsSL https://railway.app/install.sh | sh; then
+            echo "Railway CLI installed"
+          else
+            echo "Failed to install Railway CLI"
+            exit 1
+          fi
+          echo "$HOME/.railway/bin" >> $GITHUB_PATH
+
+      - name: Run diagnostic query
+        id: diagnostic
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          BACKEND_URL: ${{ secrets.PRODUCTION_BACKEND_URL }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          echo "Processing diagnostic request..."
+
+          # Get recent backend logs
+          echo "=== Recent Backend Logs ===" > /tmp/diagnostic_output.txt
+          railway logs --service backend --limit 30 2>&1 >> /tmp/diagnostic_output.txt || echo "Unable to fetch backend logs" >> /tmp/diagnostic_output.txt
+
+          echo "" >> /tmp/diagnostic_output.txt
+          echo "=== Service Status ===" >> /tmp/diagnostic_output.txt
+          railway status 2>&1 >> /tmp/diagnostic_output.txt || echo "Unable to get status" >> /tmp/diagnostic_output.txt
+
+          # If the request mentions a specific user, try to find relevant logs
+          if echo "$COMMENT_BODY" | grep -qi "user\|username"; then
+            echo "" >> /tmp/diagnostic_output.txt
+            echo "=== User-Related Logs ===" >> /tmp/diagnostic_output.txt
+            railway logs --service backend --limit 100 2>&1 | grep -i "user\|auth\|login\|register" | tail -20 >> /tmp/diagnostic_output.txt || echo "No user-related logs found" >> /tmp/diagnostic_output.txt
+          fi
+
+          # If the request mentions database or DB
+          if echo "$COMMENT_BODY" | grep -qi "database\|db\|postgres"; then
+            echo "" >> /tmp/diagnostic_output.txt
+            echo "=== Database Connection Status ===" >> /tmp/diagnostic_output.txt
+            # Check health endpoint which includes DB status
+            if [ -n "$BACKEND_URL" ]; then
+              curl -s "$BACKEND_URL/health/ready" 2>&1 >> /tmp/diagnostic_output.txt || echo "Health check unavailable" >> /tmp/diagnostic_output.txt
+            fi
+          fi
+
+          # Output for next step
+          DIAGNOSTIC_OUTPUT=$(cat /tmp/diagnostic_output.txt)
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$DIAGNOSTIC_OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Post diagnostic results
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} --body "## 🔧 DevOps Diagnostic Results
+
+          <details>
+          <summary>📋 Diagnostic Output (click to expand)</summary>
+
+          \`\`\`
+          ${{ steps.diagnostic.outputs.output }}
+          \`\`\`
+
+          </details>
+
+          ---
+          **Need more info?** You can request:
+          - \`@devops check user <username>\` - Look for user-related logs
+          - \`@devops check database\` - Check DB connection status
+          - \`@devops check logs <service>\` - Get recent logs for a service
+
+          **Note:** For direct database queries, use \`railway connect postgres\` locally with your Railway token."
+
   # ===========================================
   # HEALTH MONITORING (runs every 5 minutes)
   # ===========================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,6 +423,17 @@ railway status                      # Check project status
 - `PRODUCTION_BACKEND_URL` - For health checks
 - `PRODUCTION_FRONTEND_URL` - For health checks
 
+**Inter-Agent Diagnostics:**
+
+Other agents (like Code Agent) can request production diagnostics by commenting `@devops` on issues:
+```
+@devops please check user logs for authentication errors
+@devops check database connection status
+@devops check recent backend logs
+```
+
+DevOps Agent will query production and post results back to the issue. This enables Code Agent to verify production state when debugging issues without having direct production access.
+
 ### Agent Visibility (IMPORTANT)
 
 All agents MUST post progress updates to their issues for visibility using the **checkbox progress pattern**.


### PR DESCRIPTION
## Summary

Enables Code Agent to request production diagnostics from DevOps Agent by commenting `@devops` on issues.

- Added `issue_comment` trigger to devops.yml for @devops mentions
- Added `diagnostic-request` job that queries Railway logs/status
- Updated bug-fix.yml with instructions on requesting diagnostics  
- Updated agent definitions with inter-agent communication docs
- Updated CLAUDE.md with inter-agent diagnostics documentation

## Use Case

When Code Agent is diagnosing an issue and needs to verify production data (e.g., "does this user have a pretty name in the DB?"), it can now:

1. Post a comment: `@devops please check user logs for test@example.com`
2. DevOps Agent will query production and post results
3. Code Agent can continue with accurate production data

## Test Plan

- [ ] Create a test issue
- [ ] Comment `@devops check health status`
- [ ] Verify DevOps Agent responds with diagnostic info