### PR TITLE
fix(devops): use Railway CLI -n flag instead of timeout

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -100,10 +100,10 @@ jobs:
           echo "=== Railway CLI Info ===" > /tmp/diagnostic_output.txt
           railway --version >> /tmp/diagnostic_output.txt 2>&1 || echo "Railway CLI not available" >> /tmp/diagnostic_output.txt
 
-          # Get recent backend logs (Railway CLI v3 streams indefinitely, use timeout + tail)
+          # Get recent backend logs (use -n flag to limit lines and avoid streaming forever)
           echo "" >> /tmp/diagnostic_output.txt
           echo "=== Recent Backend Logs ===" >> /tmp/diagnostic_output.txt
-          (timeout 30 railway logs --service backend 2>&1 || echo "Unable to fetch backend logs - check RAILWAY_TOKEN or timeout reached") | tail -30 >> /tmp/diagnostic_output.txt
+          railway logs --service backend -n 30 2>&1 >> /tmp/diagnostic_output.txt || echo "Unable to fetch backend logs - check RAILWAY_TOKEN" >> /tmp/diagnostic_output.txt
 
           echo "" >> /tmp/diagnostic_output.txt
           echo "=== Service Status ===" >> /tmp/diagnostic_output.txt
@@ -113,7 +113,7 @@ jobs:
           if echo "$COMMENT_BODY" | grep -qi "user\|username"; then
             echo "" >> /tmp/diagnostic_output.txt
             echo "=== User-Related Logs ===" >> /tmp/diagnostic_output.txt
-            (timeout 30 railway logs --service backend 2>&1 || echo "Unable to fetch logs") | grep -i "user\|auth\|login\|register" | tail -20 >> /tmp/diagnostic_output.txt || echo "No user-related logs found" >> /tmp/diagnostic_output.txt
+            (railway logs --service backend -n 100 2>&1 || echo "Unable to fetch logs") | grep -i "user\|auth\|login\|register" | tail -20 >> /tmp/diagnostic_output.txt || echo "No user-related logs found" >> /tmp/diagnostic_output.txt
           fi
 
           # If the request mentions database or DB
@@ -363,16 +363,16 @@ jobs:
         id: railway_logs
         continue-on-error: true
         run: |
-          # Get last 30 lines of logs from each service (Railway CLI v3 streams indefinitely, use timeout)
-          BACKEND_LOGS=$(timeout 30 railway logs --service backend 2>&1 || echo "Unable to fetch backend logs")
-          FRONTEND_LOGS=$(timeout 30 railway logs --service frontend 2>&1 || echo "Unable to fetch frontend logs")
+          # Get last 30 lines of logs from each service (use -n flag to avoid streaming)
+          BACKEND_LOGS=$(railway logs --service backend -n 30 2>&1 || echo "Unable to fetch backend logs")
+          FRONTEND_LOGS=$(railway logs --service frontend -n 30 2>&1 || echo "Unable to fetch frontend logs")
 
           echo "backend_logs<<EOF" >> $GITHUB_OUTPUT
-          echo "$BACKEND_LOGS" | tail -30 >> $GITHUB_OUTPUT
+          echo "$BACKEND_LOGS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
           echo "frontend_logs<<EOF" >> $GITHUB_OUTPUT
-          echo "$FRONTEND_LOGS" | tail -30 >> $GITHUB_OUTPUT
+          echo "$FRONTEND_LOGS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_SW_FACTORY }}
@@ -484,12 +484,12 @@ jobs:
             You have access to the Railway CLI. Key commands:
 
             ### Viewing Logs
-            **IMPORTANT:** Railway CLI v3 streams logs indefinitely. Always wrap with timeout:
+            Use the `-n` flag to limit output and avoid indefinite streaming:
             ```bash
-            timeout 30 railway logs --service backend 2>&1 | tail -50    # Get last 50 lines
-            timeout 30 railway logs --service frontend 2>&1 | tail -50   # Frontend logs
-            timeout 60 railway logs 2>&1 | tail -100                     # All services, more lines
-            railway logs --build                                          # Build logs (these don't stream)
+            railway logs --service backend -n 50     # Get last 50 lines from backend
+            railway logs --service frontend -n 50    # Get last 50 lines from frontend
+            railway logs -n 100                      # All services, more lines
+            railway logs --build                     # Build logs
             ```
 
             ### Service Management
@@ -522,7 +522,7 @@ jobs:
 
             ### For "incident-response":
             1. Check health endpoints with curl
-            2. Get Railway logs: `timeout 60 railway logs --service backend 2>&1 | tail -100`
+            2. Get Railway logs: `railway logs --service backend -n 100`
             3. Look for errors, exceptions, connection issues
             4. Check recent deployments: `gh run list --limit 10`
             5. If code issue: create a fix PR
@@ -531,7 +531,7 @@ jobs:
             8. Escalate SEV1 to @jeremymatthewwerner
 
             ### For "view-logs":
-            1. Run `timeout 60 railway logs --service ${{ github.event.inputs.service }} 2>&1 | tail -100`
+            1. Run `railway logs --service ${{ github.event.inputs.service }} -n 100`
             2. Look for patterns: errors, warnings, slow queries
             3. Summarize findings in a new issue or comment
 
@@ -635,8 +635,8 @@ jobs:
                - Ensure health checks cover critical dependencies (DB, cache, etc.)
 
             2. **Logging**
-               - Run `timeout 30 railway logs --service backend 2>&1 | tail -50` and `timeout 30 railway logs --service frontend 2>&1 | tail -50`
-               - Note: Railway CLI v3 streams indefinitely, so always use timeout wrapper
+               - Run `railway logs --service backend -n 50` and `railway logs --service frontend -n 50`
+               - Use the `-n` flag to limit output and avoid indefinite streaming
                - Check logs have proper structure (timestamps, levels, context)
                - Look for any recurring errors that need attention
 


### PR DESCRIPTION
## Summary

Improves the Railway log fetching by using the proper `-n` flag instead of `timeout + tail`.

## What Changed

- Use `railway logs --service backend -n 30` instead of `timeout 30 railway logs ... | tail -30`
- The `-n` flag limits output to N lines and exits cleanly
- This should actually return log content instead of timing out

## Background

From [fig.io Railway docs](https://fig.io/manual/railway/logs), the `-n, --lines` flag exists but wasn't shown in the official Railway docs. This is cleaner than the timeout approach.

## Test Plan

- [ ] Merge this PR
- [ ] Post `@devops check backend logs` on issue #195
- [ ] Verify actual log lines are returned (not "Unable to fetch")