### PR TITLE
debug(devops): add service list to diagnose empty logs

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -100,14 +100,19 @@ jobs:
           echo "=== Railway CLI Info ===" > /tmp/diagnostic_output.txt
           railway --version >> /tmp/diagnostic_output.txt 2>&1 || echo "Railway CLI not available" >> /tmp/diagnostic_output.txt
 
-          # Get recent backend logs (use -n flag to limit lines and avoid streaming forever)
+          # List available services for debugging
           echo "" >> /tmp/diagnostic_output.txt
-          echo "=== Recent Backend Logs ===" >> /tmp/diagnostic_output.txt
-          railway logs --service backend -n 30 2>&1 >> /tmp/diagnostic_output.txt || echo "Unable to fetch backend logs - check RAILWAY_TOKEN" >> /tmp/diagnostic_output.txt
+          echo "=== Available Services ===" >> /tmp/diagnostic_output.txt
+          railway service list 2>&1 >> /tmp/diagnostic_output.txt || echo "Unable to list services" >> /tmp/diagnostic_output.txt
 
           echo "" >> /tmp/diagnostic_output.txt
           echo "=== Service Status ===" >> /tmp/diagnostic_output.txt
           timeout 15 railway status 2>&1 >> /tmp/diagnostic_output.txt || echo "Unable to get status - token may not be linked to project" >> /tmp/diagnostic_output.txt
+
+          # Get recent backend logs (use -n flag to limit lines and avoid streaming forever)
+          echo "" >> /tmp/diagnostic_output.txt
+          echo "=== Recent Backend Logs ===" >> /tmp/diagnostic_output.txt
+          railway logs --service backend -n 30 2>&1 >> /tmp/diagnostic_output.txt || echo "Unable to fetch backend logs - check RAILWAY_TOKEN" >> /tmp/diagnostic_output.txt
 
           # If the request mentions a specific user, try to find relevant logs
           if echo "$COMMENT_BODY" | grep -qi "user\|username"; then


### PR DESCRIPTION
Adding 'railway service list' output to see what services the token can access