### PR TITLE
fix(devops): add --environment production to railway logs

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -96,21 +96,18 @@ jobs:
         run: |
           echo "Processing diagnostic request..."
 
-          # Check Railway CLI version and available flags
+          # Check Railway CLI version
           echo "=== Railway CLI Info ===" > /tmp/diagnostic_output.txt
           railway --version >> /tmp/diagnostic_output.txt 2>&1 || echo "Railway CLI not available" >> /tmp/diagnostic_output.txt
-          echo "" >> /tmp/diagnostic_output.txt
-          echo "=== railway logs --help ===" >> /tmp/diagnostic_output.txt
-          railway logs --help 2>&1 >> /tmp/diagnostic_output.txt || true
 
           echo "" >> /tmp/diagnostic_output.txt
           echo "=== Service Status ===" >> /tmp/diagnostic_output.txt
           timeout 15 railway status 2>&1 >> /tmp/diagnostic_output.txt || echo "Unable to get status" >> /tmp/diagnostic_output.txt
 
-          # Try logs without -n flag first to see raw error
+          # Get backend logs - explicitly specify service AND environment
           echo "" >> /tmp/diagnostic_output.txt
-          echo "=== Backend Logs (raw, 5s timeout) ===" >> /tmp/diagnostic_output.txt
-          timeout 5 railway logs --service backend 2>&1 >> /tmp/diagnostic_output.txt || echo "(timeout or error)" >> /tmp/diagnostic_output.txt
+          echo "=== Recent Backend Logs ===" >> /tmp/diagnostic_output.txt
+          railway logs --service backend --environment production -n 30 2>&1 >> /tmp/diagnostic_output.txt || echo "Unable to fetch backend logs" >> /tmp/diagnostic_output.txt
 
           # If the request mentions a specific user, try to find relevant logs
           if echo "$COMMENT_BODY" | grep -qi "user\|username"; then


### PR DESCRIPTION
Explicitly specify environment in railway logs command based on --help output