### PR TITLE
fix(devops): revert to RAILWAY_TOKEN_SW_FACTORY which user updated

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Run diagnostic query
         id: diagnostic
         env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_SW_FACTORY }}
           BACKEND_URL: ${{ secrets.PRODUCTION_BACKEND_URL }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
@@ -391,7 +391,7 @@ jobs:
           echo "$FRONTEND_LOGS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_SW_FACTORY }}
 
       - name: Update or create incident
         run: |
@@ -480,7 +480,7 @@ jobs:
           # Railway CLI auto-detects project from RAILWAY_TOKEN in CI mode
           railway status || echo "Railway not linked - some features may be limited"
         env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_SW_FACTORY }}
 
       - name: Run DevOps Agent
         uses: anthropics/claude-code-action@v1
@@ -600,7 +600,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_SW_FACTORY }}
           PRODUCTION_BACKEND_URL: ${{ secrets.PRODUCTION_BACKEND_URL }}
           PRODUCTION_FRONTEND_URL: ${{ secrets.PRODUCTION_FRONTEND_URL }}
 
@@ -694,7 +694,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_SW_FACTORY }}
 
   # ===========================================
   # AUTO-REBASE (triggered on push to main)


### PR DESCRIPTION
## Summary
- Revert to using `RAILWAY_TOKEN_SW_FACTORY`
- User updated this secret with a new Account API token (with correct workspace scope)
- The update happened before PR #202 changed the workflow to use `RAILWAY_TOKEN`

## Test plan
- [ ] Merge and test with `@devops check backend logs` on issue #195
- [ ] Verify diagnostic output shows actual logs

Relates to #195