### PR TITLE
fix(devops): move workspace ID to secret

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -91,6 +91,7 @@ jobs:
         id: diagnostic
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_SW_FACTORY }}
+          RAILWAY_WORKSPACE_ID: ${{ secrets.RAILWAY_WORKSPACE_ID }}
           BACKEND_URL: ${{ secrets.PRODUCTION_BACKEND_URL }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
@@ -114,11 +115,10 @@ jobs:
           # Query Railway API to list services (GraphQL) - use workspace query for workspace-scoped tokens
           echo "" >> /tmp/diagnostic_output.txt
           echo "=== Railway API - Services ===" >> /tmp/diagnostic_output.txt
-          WORKSPACE_ID="f746dd48-51f9-47e1-a6eb-325b3c06e9ba"
           curl -s -X POST https://backboard.railway.app/graphql/v2 \
             -H "Authorization: Bearer $RAILWAY_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "{\"query\": \"query { workspace(workspaceId: \\\"$WORKSPACE_ID\\\") { projects { edges { node { id name services { edges { node { id name } } } } } } } }\"}" \
+            -d "{\"query\": \"query { workspace(workspaceId: \\\"$RAILWAY_WORKSPACE_ID\\\") { projects { edges { node { id name services { edges { node { id name } } } } } } } }\"}" \
             2>&1 >> /tmp/diagnostic_output.txt || echo "API query failed" >> /tmp/diagnostic_output.txt
 
           # Get backend logs - explicitly specify service AND environment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Ensure these secrets are set in **Settings → Secrets and variables → Actions
 - `GITHUB_TOKEN` - Auto-provided, but verify workflow permissions
 - `PAT_WITH_WORKFLOW_ACCESS` - Personal Access Token with `workflow` scope (for Code Agent to modify workflows)
 - `RAILWAY_TOKEN` - Railway API token (for DevOps Agent infrastructure management)
+- `RAILWAY_WORKSPACE_ID` - Railway workspace ID (UUID from Railway dashboard URL)
 - `PRODUCTION_BACKEND_URL` - Backend URL for health checks (e.g., `https://api.diningphilosophers.ai`)
 - `PRODUCTION_FRONTEND_URL` - Frontend URL for health checks (e.g., `https://diningphilosophers.ai`)
 - `TEST_CLEANUP_SECRET` - Secret for test user cleanup endpoint (used by smoke/canary tests)
@@ -419,7 +420,8 @@ railway status                      # Check project status
 ```
 
 **Required Secrets:**
-- `RAILWAY_TOKEN` - Get from Railway dashboard → Account → Tokens
+- `RAILWAY_TOKEN` - Get from Railway dashboard → Account → Tokens (workspace-scoped)
+- `RAILWAY_WORKSPACE_ID` - Railway workspace UUID (visible in dashboard URL)
 - `PRODUCTION_BACKEND_URL` - For health checks
 - `PRODUCTION_FRONTEND_URL` - For health checks
 


### PR DESCRIPTION
## Summary
- Move hardcoded workspace ID to `RAILWAY_WORKSPACE_ID` secret
- Update CLAUDE.md to document the new required secret

## Action Required
Add GitHub secret:
- **Name:** `RAILWAY_WORKSPACE_ID`
- **Value:** `f746dd48-51f9-47e1-a6eb-325b3c06e9ba`

Relates to #195