### PR TITLE
feat(agents): add @mention-based agent coordination and fix CI re-triggering

### DIFF
--- a/.github/workflows/ci-failure-monitor.yml
+++ b/.github/workflows/ci-failure-monitor.yml
@@ -122,12 +122,14 @@ jobs:
             --repo ${{ github.repository }} \
             --add-label "ai-ready"
 
-      - name: Update existing issue
+      - name: Update existing issue and re-trigger Code Agent
         if: steps.check-issue.outputs.exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.check-issue.outputs.issue_number }}
         run: |
-          gh issue comment ${{ steps.check-issue.outputs.issue_number }} \
+          # Comment with @claude mention to trigger Code Agent
+          gh issue comment "$ISSUE_NUMBER" \
             --repo ${{ github.repository }} \
             --body "## Another CI Failure Detected
 
@@ -135,4 +137,9 @@ jobs:
           **Commit:** ${{ github.event.workflow_run.head_sha }}
           **Run:** ${{ steps.failed-jobs.outputs.run_url }}
 
-          The CI is still failing. Please investigate."
+          @claude The CI is still failing on main. Please investigate this new failure and fix it."
+
+          # Also re-trigger via label toggle (belt and suspenders)
+          gh issue edit "$ISSUE_NUMBER" --repo ${{ github.repository }} --remove-label "ai-ready" || true
+          sleep 2
+          gh issue edit "$ISSUE_NUMBER" --repo ${{ github.repository }} --add-label "ai-ready"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -556,6 +556,33 @@ Issue Created → Triage labels → Code Agent fixes → PR created → CI passe
 
 **Concurrency:** Only one bot run per issue at a time. Comments are queued, not dropped.
 
+### Agent-to-Agent Coordination (@mentions)
+
+Agents can request help from other agents using @mentions in issue comments. This is the preferred method for agent coordination because:
+- **Comments are immutable** - creates audit trail
+- **Each mention is an event** - triggers workflow reliably
+- **Simple to understand** - no complex state machine
+- **Works regardless of labels** - doesn't depend on ephemeral label state
+
+**Available @mentions:**
+
+| Mention | Triggers | Use Case |
+|---------|----------|----------|
+| `@claude` | Code Agent | Ask for code changes, bug fixes, feature implementation |
+| `@devops` | DevOps Agent | Request production logs, database diagnostics, service restarts |
+| `@principal-engineer` | Principal Engineer | Escalate complex issues requiring holistic factory fixes |
+
+**Examples:**
+```
+@devops please check backend logs for errors in the last hour
+@claude the database schema needs updating, please create a migration
+@devops check database connection status
+```
+
+**When to use @mentions vs labels:**
+- **@mentions**: Agent-to-agent requests, re-triggering stuck issues, requesting specific actions
+- **Labels**: Initial triage, marking issues as ready for automation (`ai-ready`), escalation states
+
 ### QA Agent - Test Quality Guardian
 
 The QA agent performs **periodic reflection and enhancement** of the test suite:


### PR DESCRIPTION
## Summary

Fixes agent coordination gaps where agents couldn't re-trigger each other effectively.

## Problems Fixed

1. **CI Failure Monitor dead-end**: When CI failed again on an existing issue, it only commented "Please investigate" without actually triggering anyone. Now uses both `@claude` mention and label toggle.

2. **Documented @mention pattern**: Agents can now reliably coordinate via @mentions in comments:
   - `@claude` - triggers Code Agent
   - `@devops` - triggers DevOps Agent  
   - `@principal-engineer` - triggers Principal Engineer

## Why @mentions > Labels

| Aspect | @mentions | Labels |
|--------|-----------|--------|
| State | Immutable (audit trail) | Ephemeral (can change) |
| Triggering | Each mention = event | Only triggers on *addition* |
| Complexity | Simple | Complex state machine |
| Re-triggering | Just mention again | Remove + re-add |

## Test plan

- [ ] CI passes
- [ ] Manually verify @claude mention triggers Code Agent