### PR TITLE
fix(devops): use PAT to trigger workflows when re-triggering Code Agent

### DIFF
--- a/.github/workflows/ci-failure-monitor.yml
+++ b/.github/workflows/ci-failure-monitor.yml
@@ -125,10 +125,11 @@ jobs:
       - name: Update existing issue and re-trigger Code Agent
         if: steps.check-issue.outputs.exists == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # MUST use PAT to trigger other workflows - GITHUB_TOKEN can't trigger workflows
+          GH_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
           ISSUE_NUMBER: ${{ steps.check-issue.outputs.issue_number }}
         run: |
-          # Comment with @claude mention to trigger Code Agent
+          # Comment about the new failure
           gh issue comment "$ISSUE_NUMBER" \
             --repo ${{ github.repository }} \
             --body "## Another CI Failure Detected
@@ -139,7 +140,7 @@ jobs:
 
           @claude The CI is still failing on main. Please investigate this new failure and fix it."
 
-          # Also re-trigger via label toggle (belt and suspenders)
+          # Re-trigger Code Agent via label toggle (PAT required to trigger workflows)
           gh issue edit "$ISSUE_NUMBER" --repo ${{ github.repository }} --remove-label "ai-ready" || true
           sleep 2
           gh issue edit "$ISSUE_NUMBER" --repo ${{ github.repository }} --add-label "ai-ready"

--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -742,7 +742,8 @@ jobs:
 
       - name: Auto-rebase conflicting PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # MUST use PAT to trigger other workflows when re-adding ai-ready label
+          GH_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
         run: |
           echo "🔄 Checking for PRs with merge conflicts after push to main..."
           echo "   Repository: $GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary

Fixes the dead-end where agents try to re-trigger Code Agent but it never runs.

## Root Cause

`GITHUB_TOKEN` cannot trigger other workflows (GitHub prevents this to avoid infinite loops).

When CI Failure Monitor or DevOps agent commented `@claude` or toggled the `ai-ready` label, Code Agent never got triggered because they were using `GITHUB_TOKEN`.

## Fix

Use `PAT_WITH_WORKFLOW_ACCESS` in:
- CI Failure Monitor when re-triggering on existing issues
- DevOps auto-rebase when closing PR and re-triggering Code Agent

## Test plan

- [ ] CI passes
- [ ] Verify next CI failure on existing issue triggers Code Agent