### PR TITLE
fix(workflow): prevent premature issue closure before deploy

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -524,13 +524,13 @@ jobs:
             ## Step 3: Create/Update PR
             1. Check fifth box [x] and update status to "Creating PR..."
             2. **ALWAYS work on a branch, NEVER push directly to main!**
-               - Pushing to main with "Fixes #N" auto-closes issues even if PR hasn't merged
                - Create branch: git checkout -b fix/${{ steps.context.outputs.number }}-description
             3. Commit with message: "fix: description\n\nRelates to #${{ steps.context.outputs.number }}"
-               - Use "Relates to #N" in commits (NOT "Fixes #N" - that auto-closes issues!)
+               - Use "Relates to #N" in commits (NOT "Fixes #N" - that auto-closes issues prematurely!)
             4. Push to branch and create PR:
-               gh pr create --title "fix: ..." --body "Fixes #${{ steps.context.outputs.number }}"
-               - Put "Fixes #N" only in PR description (closes issue when PR merges)
+               gh pr create --title "fix: ..." --body "Relates to #${{ steps.context.outputs.number }}"
+               - ALWAYS use "Relates to #N" (NOT "Fixes #N") - issues are closed by CI after deploy+smoke tests pass
+               - Using "Fixes #N" closes issues on PR merge, BEFORE code is deployed to production!
             5. Check sixth box [x] and add PR link to progress comment
             6. Final status: "✅ PR created! Waiting for CI..."
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,15 +300,13 @@ uv run mypy .           # Type check Python code
 3. Push to feature branch and create PR
 4. CI runs on PR - must pass before merge
 5. Merge PR (squash) - triggers deploy
-6. Issues auto-close when PR merges
+6. Issues auto-close after deploy + smoke tests pass (handled by CI `close-issues` job)
 
 **CRITICAL: Issue Reference Rules (prevents premature closure)**
 - **In commit messages:** Use `Relates to #N` (NOT `Fixes #N`)
-- **In PR descriptions:** Use `Fixes #N` ONLY when the PR completely solves the issue
-- **For related-but-not-fixing PRs:** Use `Relates to #N` in PR description too
-  - Example: A workflow fix that "unblocks" an agent to work on an issue is NOT a fix for the issue itself
+- **In PR descriptions:** ALWAYS use `Relates to #N` (NEVER use `Fixes #N`)
 - **NEVER push directly to main** - Always use a feature branch + PR
-- **Why:** GitHub auto-closes issues when "Fixes #N" appears in PR descriptions. If your PR doesn't fully solve the issue, using "Fixes" will close it prematurely.
+- **Why:** GitHub auto-closes issues when `Fixes #N` appears in PR descriptions, but this happens on PR merge - BEFORE the code is deployed to production! We want issues to close only after deploy + smoke tests pass. The CI `close-issues` job handles this automatically.
 
 **Best practices:**
 - Commit frequently with clear messages


### PR DESCRIPTION
## Summary

Issues were being closed immediately on PR merge because agents were using `Fixes #N` in PR descriptions. But GitHub's auto-close happens on merge - **BEFORE** the code is deployed to production!

**Timeline of issue #227:**
| Time | Event |
|------|-------|
| 16:15:43Z | PR merged |
| 16:15:45Z | Issue closed (auto-close from "Fixes #227") |
| 16:21:05Z | Deploy started |
| 16:21:13Z | Deploy completed |

The user saw the issue closed but the fix wasn't in production yet!

## Changes

**bug-fix.yml:**
- Changed instructions from `Fixes #N` to `Relates to #N` in PR descriptions
- Added clear warning about why `Fixes #N` causes premature closure

**CLAUDE.md:**
- Updated to say NEVER use `Fixes #N` (was "use only when PR completely solves")
- Clarified that the CI `close-issues` job handles closing after smoke tests pass

## How it works now

1. Agent creates PR with `Relates to #N` 
2. PR merges → issue stays open
3. Deploy runs
4. Smoke tests pass
5. CI `close-issues` job closes the issue

Relates to #227