### PR TITLE
feat(agents): migrate from label-based to @mention-based triggers

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -118,9 +118,10 @@ jobs:
           contains(github.event.issue.labels.*.name, 'ai-ready')))) ||
        (github.event_name == 'issue_comment' &&
         !github.event.issue.pull_request &&
-        (contains(github.event.comment.body, '@claude') ||
+        (contains(github.event.comment.body, '@code') ||
+         contains(github.event.comment.body, '@Code') ||
+         contains(github.event.comment.body, '@claude') ||
          contains(github.event.comment.body, '@Claude') ||
-         contains(github.event.comment.body, 'claude') ||
          contains(github.event.issue.labels.*.name, 'status:awaiting-bot'))))
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/ci-failure-monitor.yml
+++ b/.github/workflows/ci-failure-monitor.yml
@@ -111,26 +111,26 @@ jobs:
           echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
           echo "Created issue #$ISSUE_NUMBER"
 
-      # Add ai-ready label separately to trigger Code Agent's labeled event
-      - name: Trigger Code Agent
+      # Trigger Code Agent via @code comment (cleaner than label toggling)
+      - name: Trigger Code Agent for new issue
         if: steps.check-issue.outputs.exists == 'false' && steps.create-issue.outputs.issue_number
         env:
-          # MUST use PAT to trigger other workflows - GITHUB_TOKEN can't trigger workflows
+          # MUST use PAT so the comment triggers Code Agent workflow
           GH_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
         run: |
-          echo "Adding ai-ready label to trigger Code Agent..."
-          gh issue edit ${{ steps.create-issue.outputs.issue_number }} \
+          echo "Posting @code comment to trigger Code Agent..."
+          gh issue comment ${{ steps.create-issue.outputs.issue_number }} \
             --repo ${{ github.repository }} \
-            --add-label "ai-ready"
+            --body "@code Please investigate and fix this CI failure. The failure logs are in the issue description above."
 
       - name: Update existing issue and re-trigger Code Agent
         if: steps.check-issue.outputs.exists == 'true'
         env:
-          # MUST use PAT to trigger other workflows - GITHUB_TOKEN can't trigger workflows
+          # MUST use PAT so the comment triggers Code Agent workflow
           GH_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
           ISSUE_NUMBER: ${{ steps.check-issue.outputs.issue_number }}
         run: |
-          # Comment about the new failure
+          # Comment about the new failure with @code to re-trigger
           gh issue comment "$ISSUE_NUMBER" \
             --repo ${{ github.repository }} \
             --body "## Another CI Failure Detected
@@ -139,9 +139,4 @@ jobs:
           **Commit:** ${{ github.event.workflow_run.head_sha }}
           **Run:** ${{ steps.failed-jobs.outputs.run_url }}
 
-          @claude The CI is still failing on main. Please investigate this new failure and fix it."
-
-          # Re-trigger Code Agent via label toggle (PAT required to trigger workflows)
-          gh issue edit "$ISSUE_NUMBER" --repo ${{ github.repository }} --remove-label "ai-ready" || true
-          sleep 2
-          gh issue edit "$ISSUE_NUMBER" --repo ${{ github.repository }} --add-label "ai-ready"
+          @code The CI is still failing on main. Please investigate this new failure and fix it."

--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -483,9 +483,10 @@ jobs:
       - name: Trigger Code Agent for incident
         if: steps.incident.outputs.created == 'true'
         run: |
-          # Add ai-ready label separately to trigger Code Agent
-          # MUST use PAT to trigger other workflows - GITHUB_TOKEN can't trigger workflows
-          gh issue edit ${{ steps.incident.outputs.issue_number }} --add-label "ai-ready"
+          # Post @code comment to trigger Code Agent (cleaner than label approach)
+          # MUST use PAT so the comment triggers Code Agent workflow
+          gh issue comment ${{ steps.incident.outputs.issue_number }} \
+            --body "@code This is a production incident. Please investigate immediately using the Railway logs above and fix the issue."
         env:
           GH_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
 

--- a/.github/workflows/principal-engineer.yml
+++ b/.github/workflows/principal-engineer.yml
@@ -6,6 +6,8 @@ name: Principal Engineer Agent
 on:
   issues:
     types: [labeled]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       issue_number:
@@ -27,10 +29,18 @@ concurrency:
 
 jobs:
   investigate:
-    # Only trigger on needs-principal-engineer label (escalation from Code Agent)
+    # Triggers on:
+    # 1. needs-principal-engineer label (escalation from Code Agent)
+    # 2. @pe or @principal-engineer mention in comment
+    # 3. Manual workflow dispatch
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issues' && github.event.label.name == 'needs-principal-engineer')
+      (github.event_name == 'issues' && github.event.label.name == 'needs-principal-engineer') ||
+      (github.event_name == 'issue_comment' &&
+       !github.event.issue.pull_request &&
+       (contains(github.event.comment.body, '@pe') ||
+        contains(github.event.comment.body, '@PE') ||
+        contains(github.event.comment.body, '@principal-engineer')))
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -2,6 +2,8 @@ name: Triage Agent
 on:
   issues:
     types: [opened]  # Only on NEW issues, not reopened (avoid re-triaging)
+  issue_comment:
+    types: [created]  # Trigger on @triage mentions for re-triaging
   workflow_dispatch:
     inputs:
       issue_number:
@@ -16,6 +18,17 @@ permissions:
 
 jobs:
   triage:
+    # Triggers on:
+    # 1. New issue opened
+    # 2. @triage mention in comment (for re-triaging)
+    # 3. Manual workflow dispatch
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'issues' ||
+      (github.event_name == 'issue_comment' &&
+       !github.event.issue.pull_request &&
+       (contains(github.event.comment.body, '@triage') ||
+        contains(github.event.comment.body, '@Triage')))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -57,16 +70,31 @@ jobs:
             2. Check for duplicates: gh issue list --search "similar terms"
             3. Classify as bug, feature/enhancement, or question
             4. Assign priority: P0 (critical), P1 (high), P2 (medium)
-            5. Add classification and priority labels FIRST: gh issue edit ${{ steps.issue.outputs.number }} --add-label "bug,priority-low" (or enhancement, P0, P1, P2, etc.)
-            6. Comment with your assessment: gh issue comment ${{ steps.issue.outputs.number }} --body "..."
-            7. IMPORTANT: Add 'ai-ready' label LAST, in a SEPARATE command: gh issue edit ${{ steps.issue.outputs.number }} --add-label "ai-ready"
-               This ensures the Code Agent triggers correctly (it checks for bug/enhancement labels when ai-ready is added).
+            5. Add classification and priority labels: gh issue edit ${{ steps.issue.outputs.number }} --add-label "bug,priority-low" (or enhancement, priority-high, etc.)
+            6. Post your triage assessment AND trigger Code Agent with @code mention:
+               gh issue comment ${{ steps.issue.outputs.number }} --body "## 🤖 Triage Assessment
 
-            Available labels: bug, enhancement, ai-ready, P0, P1, P2, needs-human
+            **Classification:** Bug/Enhancement
+            **Priority:** High/Medium/Low (P1/P2/P3)
+            **Status:** Ready for autonomous fix
+
+            ### Analysis
+            [Your analysis here]
+
+            ### Next Steps
+            @code please investigate and fix this issue.
+
+            ---
+            *Auto-triaged by Triage Agent*"
+
+            IMPORTANT: The @code mention triggers Code Agent. Do NOT add 'ai-ready' label anymore.
+
+            Available labels: bug, enhancement, priority-high, priority-medium, priority-low, needs-human
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --dangerously-skip-permissions
             --allowedTools "Bash(gh issue:*),Bash(gh search:*),Read,Glob,Grep"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT so the @code comment triggers Code Agent workflow
+          GH_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
+          GITHUB_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -557,30 +557,38 @@ Issue Created → Triage labels → Code Agent fixes → PR created → CI passe
 
 ### Agent-to-Agent Coordination (@mentions)
 
-Agents can request help from other agents using @mentions in issue comments. This is the preferred method for agent coordination because:
+**@mentions are the primary trigger mechanism for agents.** Labels are for categorization only.
+
+Why @mentions over labels:
 - **Comments are immutable** - creates audit trail
-- **Each mention is an event** - triggers workflow reliably
-- **Simple to understand** - no complex state machine
-- **Works regardless of labels** - doesn't depend on ephemeral label state
+- **No race conditions** - unlike labels which can conflict when added together
+- **No PAT workarounds** - comments reliably trigger workflows
+- **Simple to understand** - no complex "if has X AND Y" conditions
 
 **Available @mentions:**
 
-| Mention | Triggers | Use Case |
-|---------|----------|----------|
-| `@claude` | Code Agent | Ask for code changes, bug fixes, feature implementation |
-| `@devops` | DevOps Agent | Request production logs, database diagnostics, service restarts |
-| `@principal-engineer` | Principal Engineer | Escalate complex issues requiring holistic factory fixes |
+| Mention | Agent | Use Case |
+|---------|-------|----------|
+| `@code` | Code Agent | Fix bugs, implement features (preferred over `@claude`) |
+| `@devops` | DevOps Agent | Production logs, diagnostics, service restarts |
+| `@pe` | Principal Engineer | Holistic debugging, factory fixes |
+| `@triage` | Triage Agent | Re-classify or re-prioritize an issue |
+| `@qa` | QA Agent | Request test improvements |
+| `@claude` | Code Agent | Legacy alias for `@code` (still works) |
 
 **Examples:**
 ```
-@devops please check backend logs for errors in the last hour
-@claude the database schema needs updating, please create a migration
-@devops check database connection status
+@code please fix this bug
+@devops please check backend logs for errors
+@pe this issue needs holistic investigation
+@triage please re-evaluate the priority of this issue
 ```
 
-**When to use @mentions vs labels:**
-- **@mentions**: Agent-to-agent requests, re-triggering stuck issues, requesting specific actions
-- **Labels**: Initial triage, marking issues as ready for automation (`ai-ready`), escalation states
+**Labels are for categorization only:**
+- `bug`, `enhancement` - Issue type
+- `priority-high`, `priority-medium`, `priority-low` - Priority
+- `status:bot-working`, `status:awaiting-human` - Current status
+- Do NOT use `ai-ready` label to trigger agents - use `@code` mention instead
 
 ### QA Agent - Test Quality Guardian
 


### PR DESCRIPTION
## Summary

Major improvement to agent coordination reliability by migrating from label-based triggers to @mention-based triggers.

## Problem

Labels have caused multiple issues:
- Race conditions when adding multiple labels at once
- `GITHUB_TOKEN` can't trigger workflows via label events (need PAT workarounds)
- Complex "if has X AND Y" conditions
- Ephemeral state that's hard to debug

## Solution

Use @mentions as the primary trigger mechanism. Labels are now for categorization only.

## Changes

### New @mention triggers:
| Mention | Agent | Workflow |
|---------|-------|----------|
| `@code` | Code Agent | bug-fix.yml |
| `@pe` | Principal Engineer | principal-engineer.yml |
| `@triage` | Triage Agent | triage.yml |

### Workflows updated to use @code:
- **triage.yml**: Posts `@code please investigate` instead of adding `ai-ready` label
- **ci-failure-monitor.yml**: Posts `@code` comment instead of label toggle
- **devops.yml** (incidents): Posts `@code` comment instead of adding `ai-ready`

### Documentation:
- CLAUDE.md updated with full @mention table
- Clarified that labels are for categorization only

## Benefits

1. **No race conditions** - Comments are atomic events
2. **No PAT workarounds** - Comments trigger `issue_comment` events reliably  
3. **Audit trail** - Comments are immutable
4. **Simpler logic** - "if comment contains @code" vs complex label conditions

## Backward Compatibility

- `@claude` still works (alongside new `@code`)
- `ai-ready` label trigger still works (will be removed in Phase 3)

Relates to #238