### PR TITLE
fix(workflows): properly configure git to use PAT for workflow pushes

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -132,9 +132,13 @@ jobs:
           token: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
 
       # Configure git to use PAT for push operations (enables pushing workflow files)
+      # The checkout action uses extraheader for auth, so we must override it with the PAT
       - name: Configure git with PAT
         run: |
-          git config --global url."https://x-access-token:${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}@github.com/".insteadOf "https://github.com/"
+          # Remove the default extraheader set by checkout (uses GitHub App token)
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          # Set extraheader with PAT that has workflow scope
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n 'x-access-token:${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}' | base64)"
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Problem

The previous fix using `url.insteadOf` didn't work because the checkout action uses `http.extraheader` for authentication, not URL-embedded credentials.

The push still failed with:
```
refusing to allow a GitHub App to create or update workflow 
`.github/workflows/devops.yml` without `workflows` permission
```

## Solution

This fix:
1. Removes the default extraheader set by checkout (which uses the GitHub App token)
2. Sets a new extraheader with the PAT that has workflow scope

```yaml
# Remove the default extraheader set by checkout (uses GitHub App token)
git config --local --unset-all http.https://github.com/.extraheader || true
# Set extraheader with PAT that has workflow scope
git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n 'x-access-token:PAT' | base64)"
```

Relates to #243