### PR TITLE
fix(workflows): remove embedded token from URL before setting PAT extraheader

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -132,11 +132,11 @@ jobs:
           token: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
 
       # Configure git to use PAT for push operations (enables pushing workflow files)
-      # The checkout action uses extraheader for auth, so we must override it with the PAT
+      # The checkout action embeds the token in the remote URL, so we must replace it
       - name: Configure git with PAT
         run: |
-          # Remove the default extraheader set by checkout (uses GitHub App token)
-          git config --local --unset-all http.https://github.com/.extraheader || true
+          # Remove the embedded token from the remote URL (checkout embeds ghs_* token)
+          git remote set-url origin https://github.com/${{ github.repository }}.git
           # Set extraheader with PAT that has workflow scope
           git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n 'x-access-token:${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}' | base64)"
 


### PR DESCRIPTION
## Problem

The checkout action embeds the token directly in the remote URL as `https://x-access-token:ghs_***@github.com/...`. Git uses this URL-embedded token and ignores the extraheader.

## Solution

1. Reset the remote URL to remove the embedded token: `git remote set-url origin https://github.com/REPO.git`
2. Set the extraheader with the PAT that has workflow scope

Relates to #243