### PR TITLE
chore(workflows): remove legacy label-based triggers (Phase 3)

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -1,7 +1,5 @@
 name: Code Agent
 on:
-  issues:
-    types: [labeled]
   issue_comment:
     types: [created]
   schedule:
@@ -101,23 +99,16 @@ jobs:
 
   fix:
     # Triggers on:
-    # 1. ai-ready label added AND issue already has (bug OR enhancement)
-    # 2. bug/enhancement label added AND issue already has ai-ready
-    # 3. Comment containing @claude on an issue with ai-ready label
-    # 4. ANY comment on an issue with status:awaiting-bot label (human responded)
-    # 5. Manual workflow dispatch
+    # 1. Comment containing @code or @claude on an issue
+    # 2. ANY comment on an issue with status:awaiting-bot label (human responded)
+    # 3. Manual workflow dispatch
     # SKIP if: needs-human label is present (escalated, requires human intervention)
     # SKIP if: factory-meta label is present (handled by Factory Manager only)
+    # NOTE: Legacy ai-ready label triggers removed - use @code mention instead
     if: |
       !contains(github.event.issue.labels.*.name, 'needs-human') &&
       !contains(github.event.issue.labels.*.name, 'factory-meta') &&
       (github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'issues' &&
-        ((github.event.label.name == 'ai-ready' &&
-          (contains(github.event.issue.labels.*.name, 'bug') ||
-           contains(github.event.issue.labels.*.name, 'enhancement'))) ||
-         ((github.event.label.name == 'bug' || github.event.label.name == 'enhancement') &&
-          contains(github.event.issue.labels.*.name, 'ai-ready')))) ||
        (github.event_name == 'issue_comment' &&
         !github.event.issue.pull_request &&
         (contains(github.event.comment.body, '@code') ||

--- a/.github/workflows/principal-engineer.yml
+++ b/.github/workflows/principal-engineer.yml
@@ -4,8 +4,6 @@ name: Principal Engineer Agent
 # This agent takes a holistic approach to fix the factory, not just the symptom
 
 on:
-  issues:
-    types: [labeled]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -30,14 +28,13 @@ concurrency:
 jobs:
   investigate:
     # Triggers on:
-    # 1. needs-principal-engineer label (escalation from Code Agent)
-    # 2. @pe or @principal-engineer mention in comment
-    # 3. Manual workflow dispatch
+    # 1. @pe or @principal-engineer mention in comment
+    # 2. Manual workflow dispatch
     # SKIP if: factory-meta label is present (handled by Factory Manager only)
+    # NOTE: Legacy needs-principal-engineer label trigger removed - use @pe mention instead
     if: |
       !contains(github.event.issue.labels.*.name, 'factory-meta') &&
       (github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'issues' && github.event.label.name == 'needs-principal-engineer') ||
        (github.event_name == 'issue_comment' &&
         !github.event.issue.pull_request &&
         (contains(github.event.comment.body, '@pe') ||


### PR DESCRIPTION
## Summary

This completes **Phase 3** of the @mention migration (issue #238).

### Changes

**bug-fix.yml (Code Agent):**
- Removed `issues: labeled` event trigger
- Removed `ai-ready` label trigger logic from `if` condition
- Now triggers only via `@code`/`@claude` mentions or `status:awaiting-bot`

**principal-engineer.yml (PE Agent):**
- Removed `issues: labeled` event trigger
- Removed `needs-principal-engineer` label trigger logic from `if` condition
- Now triggers only via `@pe`/`@principal-engineer` mentions

### Benefits

- **Eliminates race conditions** - Comments are atomic events
- **Simpler logic** - No complex "if has X AND Y" conditions
- **Better audit trail** - Comments are immutable, labels can be changed

### Migration Complete

With this PR, the @mention-based trigger system is fully deployed:
- Phase 1: Added @mention triggers ✅ (PR #239)
- Phase 2: Updated triggering workflows ✅ (PR #239)
- Phase 3: Removed legacy label triggers ✅ (this PR)

Relates to #238