### PR TITLE
fix(workflow): add PAT git config to Principal Engineer workflow

### DIFF
--- a/.github/workflows/principal-engineer.yml
+++ b/.github/workflows/principal-engineer.yml
@@ -49,6 +49,15 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
 
+      # Configure git to use PAT for push operations (enables pushing workflow files)
+      # The checkout action embeds the token in the remote URL, so we must replace it
+      - name: Configure git with PAT
+        run: |
+          # Remove the embedded token from the remote URL (checkout embeds ghs_* token)
+          git remote set-url origin https://github.com/${{ github.repository }}.git
+          # Set extraheader with PAT that has workflow scope
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n 'x-access-token:${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}' | base64)"
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
## Summary

Adds the PAT git config step to `principal-engineer.yml` (same as `bug-fix.yml`).

This enables the PE Agent to push workflow file changes. Without this fix, PE Agent encounters "refusing to allow a GitHub App to create or update workflow" errors when trying to push changes.

### Changes

Added after checkout step:
```yaml
- name: Configure git with PAT
  run: |
    git remote set-url origin https://github.com/${{ github.repository }}.git
    git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n 'x-access-token:${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}' | base64)"
```

## Context

Issue #248 was created to track this fix. The Code Agent correctly identified the solution but couldn't push workflow files (chicken-and-egg problem). Applied manually via Claude Code session.

Relates to #248