### PR TITLE
fix(factory-manager): use negation for schedule matching

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -39,7 +39,7 @@ jobs:
   # ===========================================
   health-check:
     if: |
-      (github.event_name == 'schedule' && github.event.schedule == '*/5 * * * *') ||
+      (github.event_name == 'schedule' && github.event.schedule != '0 6 * * 1') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'full-health-check')
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
Fix Factory Manager scheduled health checks being skipped.

## Problem
The exact cron string comparison `github.event.schedule == '*/5 * * * *'` was failing, causing scheduled health checks to be skipped.

## Solution
Changed to negation-based matching:
- Health check runs for any schedule that is NOT the weekly report (`!= '0 6 * * 1'`)
- This is more robust than requiring exact string match for `*/5 * * * *`

## Testing
- Manual dispatch with `full-health-check` works ✅
- Scheduled runs should now trigger the health-check job