### PR TITLE
fix(factory-manager): add workflows:write permission

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -28,6 +28,7 @@ permissions:
   pull-requests: write
   actions: read
   id-token: write
+  workflows: write  # Required to push workflow file changes
 
 # Only one Factory Manager run at a time
 concurrency:


### PR DESCRIPTION
## Summary

Factory Manager was missing `workflows: write` permission, causing push failures when trying to modify workflow files.

### Error seen
```
refusing to allow a GitHub App to create or update workflow .github/workflows/ci.yml without workflows permission
```

### Fix
Added `workflows: write` to the permissions block in factory-manager.yml.

This enables Factory Manager to autonomously fix workflow issues, which is its core responsibility.

Relates to #310

## Test plan

- [ ] Merge this PR
- [ ] Trigger Factory Manager on #310 with `@factory-manager`
- [ ] Verify it can now push workflow changes