### PR TITLE
fix(factory-manager): remove invalid workflows permission

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -30,7 +30,8 @@ permissions:
   pull-requests: write
   actions: read
   id-token: write
-  workflows: write  # Required to push workflow file changes
+  # NOTE: workflows permission is only valid for PATs, not workflow files
+  # The PAT_WITH_WORKFLOW_ACCESS secret has this scope
 
 # Only one Factory Manager run at a time
 concurrency:


### PR DESCRIPTION
## CRITICAL FIX

The `workflows` permission is only valid for PATs, not workflow files. This was causing **all Factory Manager runs to fail** with a parse error:

```
(Line: 33, Col: 3): Unexpected value 'workflows'
```

## Valid workflow permissions

According to GitHub docs, the valid permissions in workflow files are:
- actions, checks, contents, deployments, id-token, issues, packages, pages, pull-requests, repository-projects, security-events, statuses

`workflows` is **NOT** in this list - it's only valid for PATs.

## Fix

Removed `workflows: write` from permissions block. The `PAT_WITH_WORKFLOW_ACCESS` secret already has the workflows scope, which is what enables pushing workflow files.

## Impact

This fix restores Factory Manager functionality. All runs since PR #314 have been failing.