### PR TITLE
feat(factory): add GitHub Apps architecture for distinct agent identities

### DIFF
--- a/.github/apps/code-agent.json
+++ b/.github/apps/code-agent.json
@@ -1,0 +1,23 @@
+{
+  "name": "DP Code Agent",
+  "description": "Autonomous code agent for fixing bugs and implementing features in Dining Philosophers",
+  "url": "https://github.com/jeremymatthewwerner/dining-philosophers-Dec25-sw-factory",
+  "hook_attributes": {
+    "url": "",
+    "active": false
+  },
+  "public": false,
+  "default_permissions": {
+    "contents": "write",
+    "issues": "write",
+    "pull_requests": "write",
+    "actions": "read",
+    "checks": "read",
+    "metadata": "read"
+  },
+  "default_events": [
+    "issue_comment",
+    "issues",
+    "pull_request"
+  ]
+}

--- a/.github/apps/devops.json
+++ b/.github/apps/devops.json
@@ -1,0 +1,25 @@
+{
+  "name": "DP DevOps Agent",
+  "description": "DevOps agent for infrastructure management, health checks, and incident response",
+  "url": "https://github.com/jeremymatthewwerner/dining-philosophers-Dec25-sw-factory",
+  "hook_attributes": {
+    "url": "",
+    "active": false
+  },
+  "public": false,
+  "default_permissions": {
+    "contents": "write",
+    "issues": "write",
+    "pull_requests": "write",
+    "actions": "read",
+    "checks": "read",
+    "metadata": "read",
+    "deployments": "write"
+  },
+  "default_events": [
+    "issue_comment",
+    "issues",
+    "deployment",
+    "deployment_status"
+  ]
+}

--- a/.github/apps/factory-manager.json
+++ b/.github/apps/factory-manager.json
@@ -1,0 +1,25 @@
+{
+  "name": "DP Factory Manager",
+  "description": "Factory Manager agent for monitoring and maintaining the autonomous software factory",
+  "url": "https://github.com/jeremymatthewwerner/dining-philosophers-Dec25-sw-factory",
+  "hook_attributes": {
+    "url": "",
+    "active": false
+  },
+  "public": false,
+  "default_permissions": {
+    "contents": "write",
+    "issues": "write",
+    "pull_requests": "write",
+    "actions": "write",
+    "checks": "read",
+    "metadata": "read",
+    "workflows": "write"
+  },
+  "default_events": [
+    "issue_comment",
+    "issues",
+    "pull_request",
+    "workflow_run"
+  ]
+}

--- a/.github/apps/qa.json
+++ b/.github/apps/qa.json
@@ -1,0 +1,21 @@
+{
+  "name": "DP QA Agent",
+  "description": "QA agent for test quality improvement and coverage analysis",
+  "url": "https://github.com/jeremymatthewwerner/dining-philosophers-Dec25-sw-factory",
+  "hook_attributes": {
+    "url": "",
+    "active": false
+  },
+  "public": false,
+  "default_permissions": {
+    "contents": "write",
+    "issues": "write",
+    "pull_requests": "write",
+    "checks": "read",
+    "metadata": "read"
+  },
+  "default_events": [
+    "issues",
+    "pull_request"
+  ]
+}

--- a/.github/apps/triage.json
+++ b/.github/apps/triage.json
@@ -1,0 +1,18 @@
+{
+  "name": "DP Triage Agent",
+  "description": "Triage agent for classifying issues, detecting duplicates, and adding labels",
+  "url": "https://github.com/jeremymatthewwerner/dining-philosophers-Dec25-sw-factory",
+  "hook_attributes": {
+    "url": "",
+    "active": false
+  },
+  "public": false,
+  "default_permissions": {
+    "contents": "read",
+    "issues": "write",
+    "metadata": "read"
+  },
+  "default_events": [
+    "issues"
+  ]
+}

--- a/.github/examples/bug-fix-with-app.yml.example
+++ b/.github/examples/bug-fix-with-app.yml.example
@@ -1,0 +1,118 @@
+# Example: Code Agent workflow using GitHub App authentication
+#
+# Key changes from PAT-based authentication:
+# 1. Use actions/create-github-app-token to get installation token
+# 2. All comments appear from "DP Code Agent[bot]"
+# 3. @mentions of the bot trigger workflows
+# 4. Can assign issues to the bot
+#
+# To migrate: Replace PAT_WITH_WORKFLOW_ACCESS with app token steps
+
+name: Code Agent
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [assigned]  # NEW: Can trigger on assignment
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to fix'
+        required: true
+        type: number
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+  actions: read
+  checks: read
+  # NOTE: No workflows:write needed - Factory Manager handles workflow changes
+
+concurrency:
+  group: code-agent-issue-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  fix:
+    # Trigger on:
+    # 1. @dp-code-agent mention in comment
+    # 2. Issue assigned to dp-code-agent[bot]
+    # 3. Manual workflow dispatch
+    if: |
+      (github.event_name == 'issue_comment' &&
+       !github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@dp-code-agent')) ||
+      (github.event_name == 'issues' &&
+       github.event.action == 'assigned' &&
+       github.event.assignee.login == 'dp-code-agent[bot]') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      # Step 1: Generate app installation token
+      # This is the key change - use the app's identity
+      - name: Generate Code Agent Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CODE_AGENT_APP_ID }}
+          private-key: ${{ secrets.CODE_AGENT_PRIVATE_KEY }}
+
+      # Step 2: Checkout with app token
+      # Commits will be attributed to "DP Code Agent[bot]"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      # Step 3: Configure git with app identity
+      - name: Configure git
+        run: |
+          git config user.name "dp-code-agent[bot]"
+          git config user.email "dp-code-agent[bot]@users.noreply.github.com"
+
+      # Step 4: Post acknowledgment (appears from app)
+      - name: Acknowledge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo ${{ github.repository }} \
+            --body "## 🤖 Code Agent Responding
+
+          I'm starting to work on this issue.
+
+          **Workflow:** [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
+      # ... rest of workflow uses ${{ steps.app-token.outputs.token }}
+      # instead of ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          # ... claude configuration
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        env:
+          # Use app token for all GitHub operations
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # When delegating to Factory Manager, the comment WILL trigger
+      # because it comes from the app, not GITHUB_TOKEN
+      - name: Delegate workflow changes (if needed)
+        if: failure() && contains(env.ERROR_MESSAGE, 'workflow')
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # This comment WILL trigger Factory Manager because it
+          # comes from the Code Agent app, not github-actions[bot]
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo ${{ github.repository }} \
+            --body "@dp-factory-manager This issue requires workflow changes.
+
+          Please see my analysis above and apply the fix."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,11 @@ Real-time multi-party chat with AI-simulated historical/contemporary thinkers.
 | `@devops` | DevOps - production logs, diagnostics |
 | `@factory-manager` | Factory Manager - stuck issues, health |
 
+> **Future: GitHub Apps** - We're migrating to GitHub Apps for each agent, which will give
+> each agent a distinct identity (e.g., `@dp-code-agent[bot]`). This enables issue assignment,
+> proper @mentions, and fixes the issue where bot comments don't trigger workflows.
+> See `docs/GITHUB_APPS.md` and run `./scripts/setup-github-apps.sh` to set up.
+
 ## Repository Setup (One-Time)
 
 **Before the autonomous factory can run without intervention, complete these steps:**
@@ -71,6 +76,15 @@ Ensure these secrets are set in **Settings → Secrets and variables → Actions
 - `DEVOPS_API_SECRET` - Secret for DevOps API endpoints (used by DevOps Agent for database maintenance)
 - `FEEDBACK_PROCESSOR_SECRET` - Secret for feedback-to-issue conversion (used by DevOps workflow to process user feedback)
 - `TEMPLATE_SYNC_TOKEN` - PAT with repo scope for pushing to template repo (used by template-sync workflow)
+
+**GitHub Apps Secrets (Optional - for distinct agent identities):**
+- `CODE_AGENT_APP_ID` / `CODE_AGENT_PRIVATE_KEY` - Code Agent GitHub App
+- `FACTORY_MANAGER_APP_ID` / `FACTORY_MANAGER_PRIVATE_KEY` - Factory Manager GitHub App
+- `DEVOPS_APP_ID` / `DEVOPS_PRIVATE_KEY` - DevOps Agent GitHub App
+- `TRIAGE_APP_ID` / `TRIAGE_PRIVATE_KEY` - Triage Agent GitHub App
+- `QA_APP_ID` / `QA_PRIVATE_KEY` - QA Agent GitHub App
+
+See `docs/GITHUB_APPS.md` for setup instructions.
 
 ### 4. Branch Protection (Optional)
 If using branch protection on `main`, ensure:

--- a/docs/GITHUB_APPS.md
+++ b/docs/GITHUB_APPS.md
@@ -1,0 +1,192 @@
+# GitHub Apps for the Autonomous Software Factory
+
+This document describes the GitHub Apps architecture that gives each agent a distinct identity.
+
+## Overview
+
+Instead of all agents appearing as `claude[bot]` or `github-actions[bot]`, each agent role has its own GitHub App:
+
+| Agent | App Name | Purpose |
+|-------|----------|---------|
+| Code Agent | `DP Code Agent` | Fixes bugs, implements features |
+| Factory Manager | `DP Factory Manager` | Monitors factory, handles workflow changes |
+| DevOps | `DP DevOps Agent` | Infrastructure, incident response |
+| Triage | `DP Triage Agent` | Classifies issues, adds labels |
+| QA | `DP QA Agent` | Test quality improvement |
+
+## Benefits
+
+1. **Distinct identities** - Each agent's comments show their specific identity
+2. **Assignable** - Issues can be assigned to agent bot accounts
+3. **Real @mentions** - `@dp-code-agent[bot]` is a real GitHub user
+4. **Workflow triggers** - App comments CAN trigger workflows (unlike GITHUB_TOKEN)
+5. **Scoped permissions** - Each app only has permissions it needs
+6. **Clear audit trail** - Easy to see which agent did what
+
+## Setup
+
+### Prerequisites
+
+- GitHub CLI (`gh`) installed and authenticated
+- Repository admin access
+
+### Creating the Apps
+
+Run the setup script:
+
+```bash
+./scripts/setup-github-apps.sh
+```
+
+This will guide you through:
+1. Creating each GitHub App
+2. Setting permissions from manifests
+3. Generating private keys
+4. Storing secrets in the repository
+5. Installing apps on the repository
+
+### Manual Setup
+
+If you prefer manual setup:
+
+1. Go to **Settings → Developer settings → GitHub Apps → New GitHub App**
+
+2. For each app, use the manifest in `.github/apps/<agent>.json`:
+   - `code-agent.json`
+   - `factory-manager.json`
+   - `devops.json`
+   - `triage.json`
+   - `qa.json`
+
+3. After creating each app:
+   - Note the **App ID**
+   - Generate a **Private Key** (.pem file)
+   - Install the app on your repository
+
+4. Store secrets in the repository:
+   - `CODE_AGENT_APP_ID` / `CODE_AGENT_PRIVATE_KEY`
+   - `FACTORY_MANAGER_APP_ID` / `FACTORY_MANAGER_PRIVATE_KEY`
+   - `DEVOPS_APP_ID` / `DEVOPS_PRIVATE_KEY`
+   - `TRIAGE_APP_ID` / `TRIAGE_PRIVATE_KEY`
+   - `QA_APP_ID` / `QA_PRIVATE_KEY`
+
+## Using Apps in Workflows
+
+### Generating Installation Tokens
+
+Use the `actions/create-github-app-token` action to get an installation token:
+
+```yaml
+steps:
+  - name: Generate App Token
+    id: app-token
+    uses: actions/create-github-app-token@v1
+    with:
+      app-id: ${{ secrets.CODE_AGENT_APP_ID }}
+      private-key: ${{ secrets.CODE_AGENT_PRIVATE_KEY }}
+
+  - name: Use the token
+    env:
+      GH_TOKEN: ${{ steps.app-token.outputs.token }}
+    run: |
+      # This comment will appear from "DP Code Agent[bot]"
+      gh issue comment 123 --body "Hello from Code Agent!"
+```
+
+### Example: Code Agent Workflow
+
+```yaml
+name: Code Agent
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  fix:
+    if: contains(github.event.comment.body, '@dp-code-agent')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Code Agent Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CODE_AGENT_APP_ID }}
+          private-key: ${{ secrets.CODE_AGENT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      # ... rest of workflow
+      # All comments/commits will appear from "DP Code Agent[bot]"
+```
+
+## Assignment-Based Workflow (Future)
+
+With GitHub Apps, we can potentially use **issue assignment** instead of labels/mentions:
+
+```yaml
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  process:
+    # Check if assigned to our bot
+    if: github.event.assignee.login == 'dp-code-agent[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      # ...
+```
+
+This would allow:
+- Drag issues to agent columns in Projects
+- Assign issues to agents like human developers
+- Clear visual representation of who's working on what
+
+## Secrets Reference
+
+| Secret | Description |
+|--------|-------------|
+| `CODE_AGENT_APP_ID` | App ID for Code Agent |
+| `CODE_AGENT_PRIVATE_KEY` | Private key for Code Agent |
+| `FACTORY_MANAGER_APP_ID` | App ID for Factory Manager |
+| `FACTORY_MANAGER_PRIVATE_KEY` | Private key for Factory Manager |
+| `DEVOPS_APP_ID` | App ID for DevOps Agent |
+| `DEVOPS_PRIVATE_KEY` | Private key for DevOps Agent |
+| `TRIAGE_APP_ID` | App ID for Triage Agent |
+| `TRIAGE_PRIVATE_KEY` | Private key for Triage Agent |
+| `QA_APP_ID` | App ID for QA Agent |
+| `QA_PRIVATE_KEY` | Private key for QA Agent |
+
+## Migrating from PAT-based Authentication
+
+The current factory uses `PAT_WITH_WORKFLOW_ACCESS` for all agents. To migrate:
+
+1. Run the setup script to create apps
+2. Update each workflow to use the appropriate app token
+3. Test that each agent appears with its correct identity
+4. Remove the old PAT once migration is verified
+
+See the migration PR for specific workflow changes.
+
+## Troubleshooting
+
+### "Resource not accessible by integration"
+
+The app doesn't have the required permission. Check:
+- App permissions in GitHub Settings → Developer settings → GitHub Apps
+- App installation on the repository
+
+### "Bad credentials"
+
+- Verify the App ID matches the installed app
+- Regenerate the private key if it's been rotated
+
+### Comments not triggering workflows
+
+Ensure the app has the relevant event subscriptions:
+- `issue_comment` for comment triggers
+- `issues` for issue triggers
+- `pull_request` for PR triggers

--- a/scripts/setup-github-apps.sh
+++ b/scripts/setup-github-apps.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# Setup GitHub Apps for the Autonomous Software Factory
+#
+# This script guides you through creating GitHub Apps for each agent role.
+# Each agent will have its own identity, enabling:
+# - Distinct @mentions that trigger workflows
+# - Issue assignment to agent accounts
+# - Clear audit trail of which agent did what
+#
+# Usage: ./scripts/setup-github-apps.sh
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Get repo info
+REPO_OWNER=$(gh repo view --json owner -q '.owner.login' 2>/dev/null || echo "")
+REPO_NAME=$(gh repo view --json name -q '.name' 2>/dev/null || echo "")
+
+if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
+    echo -e "${RED}Error: Could not determine repository. Run this from the repo root with gh CLI authenticated.${NC}"
+    exit 1
+fi
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}GitHub Apps Setup for Software Factory${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+echo -e "Repository: ${GREEN}$REPO_OWNER/$REPO_NAME${NC}"
+echo ""
+
+# Define the apps to create
+declare -A APPS=(
+    ["code-agent"]="DP Code Agent|Fixes bugs and implements features"
+    ["factory-manager"]="DP Factory Manager|Monitors and maintains the factory"
+    ["devops"]="DP DevOps Agent|Infrastructure and incident response"
+    ["triage"]="DP Triage Agent|Classifies issues and adds labels"
+    ["qa"]="DP QA Agent|Test quality improvement"
+)
+
+# Check if manifests exist
+MANIFEST_DIR=".github/apps"
+if [ ! -d "$MANIFEST_DIR" ]; then
+    echo -e "${RED}Error: Manifest directory $MANIFEST_DIR not found.${NC}"
+    exit 1
+fi
+
+echo -e "${YELLOW}This script will guide you through creating 5 GitHub Apps.${NC}"
+echo ""
+echo "For each app, you will:"
+echo "  1. Click a link to create the app on GitHub"
+echo "  2. Confirm the settings (pre-filled from manifest)"
+echo "  3. Generate a private key"
+echo "  4. Save the App ID and private key"
+echo ""
+echo -e "${YELLOW}The apps will be created under your account: $REPO_OWNER${NC}"
+echo ""
+read -p "Press Enter to continue or Ctrl+C to cancel..."
+
+# Store created apps info
+CREATED_APPS=""
+
+for app_key in "${!APPS[@]}"; do
+    IFS='|' read -r app_name app_desc <<< "${APPS[$app_key]}"
+    manifest_file="$MANIFEST_DIR/$app_key.json"
+
+    if [ ! -f "$manifest_file" ]; then
+        echo -e "${YELLOW}Warning: Manifest not found for $app_key, skipping.${NC}"
+        continue
+    fi
+
+    echo ""
+    echo -e "${BLUE}========================================${NC}"
+    echo -e "${BLUE}Creating: $app_name${NC}"
+    echo -e "${BLUE}========================================${NC}"
+    echo -e "Description: $app_desc"
+    echo ""
+
+    # Read the manifest
+    MANIFEST_CONTENT=$(cat "$manifest_file")
+
+    # URL-encode the manifest for the creation URL
+    # Note: GitHub's manifest flow uses a POST, but we can link to the creation page
+    echo -e "To create this app:"
+    echo ""
+    echo -e "  1. Go to: ${GREEN}https://github.com/settings/apps/new${NC}"
+    echo ""
+    echo -e "  2. Fill in these settings:"
+    echo -e "     - GitHub App name: ${GREEN}$app_name${NC}"
+    echo -e "     - Homepage URL: ${GREEN}https://github.com/$REPO_OWNER/$REPO_NAME${NC}"
+    echo -e "     - Uncheck 'Active' under Webhook (we don't need webhooks)"
+    echo ""
+    echo -e "  3. Set permissions (from manifest):"
+
+    # Parse and display permissions from manifest
+    echo "$MANIFEST_CONTENT" | jq -r '.default_permissions | to_entries[] | "     - \(.key): \(.value)"'
+
+    echo ""
+    echo -e "  4. Subscribe to events:"
+    echo "$MANIFEST_CONTENT" | jq -r '.default_events[]? | "     - \(.)"'
+
+    echo ""
+    echo -e "  5. Set 'Where can this GitHub App be installed?' to:"
+    echo -e "     ${GREEN}Only on this account${NC}"
+    echo ""
+    echo -e "  6. Click 'Create GitHub App'"
+    echo ""
+    echo -e "  7. After creation, note the ${GREEN}App ID${NC} shown on the app page"
+    echo ""
+    echo -e "  8. Scroll down to 'Private keys' and click ${GREEN}Generate a private key${NC}"
+    echo -e "     (A .pem file will download)"
+    echo ""
+
+    read -p "Press Enter when you've created '$app_name' and have the App ID and private key..."
+
+    # Prompt for App ID
+    read -p "Enter the App ID for $app_name: " APP_ID
+
+    # Prompt for private key file path
+    echo "Enter the path to the downloaded private key file (.pem):"
+    read -p "Path: " PEM_PATH
+
+    if [ ! -f "$PEM_PATH" ]; then
+        echo -e "${RED}Warning: File not found at $PEM_PATH${NC}"
+        read -p "Continue anyway? (y/n): " CONTINUE
+        if [ "$CONTINUE" != "y" ]; then
+            continue
+        fi
+    fi
+
+    # Convert app_key to uppercase for secret names
+    SECRET_PREFIX=$(echo "$app_key" | tr '[:lower:]-' '[:upper:]_')
+    APP_ID_SECRET="${SECRET_PREFIX}_APP_ID"
+    PRIVATE_KEY_SECRET="${SECRET_PREFIX}_PRIVATE_KEY"
+
+    echo ""
+    echo -e "Storing secrets in repository..."
+
+    # Store App ID as secret
+    echo "$APP_ID" | gh secret set "$APP_ID_SECRET" --repo "$REPO_OWNER/$REPO_NAME"
+    echo -e "${GREEN}✓ Stored $APP_ID_SECRET${NC}"
+
+    # Store private key as secret
+    if [ -f "$PEM_PATH" ]; then
+        gh secret set "$PRIVATE_KEY_SECRET" --repo "$REPO_OWNER/$REPO_NAME" < "$PEM_PATH"
+        echo -e "${GREEN}✓ Stored $PRIVATE_KEY_SECRET${NC}"
+    fi
+
+    CREATED_APPS="$CREATED_APPS\n  - $app_name (App ID: $APP_ID)"
+
+    echo ""
+    echo -e "${GREEN}✓ $app_name setup complete!${NC}"
+    echo ""
+
+    # Install the app on the repo
+    echo -e "Now install the app on this repository:"
+    echo -e "  1. Go to: ${GREEN}https://github.com/settings/apps/${app_name// /-}/installations${NC}"
+    echo -e "  2. Click 'Install'"
+    echo -e "  3. Select 'Only select repositories' and choose ${GREEN}$REPO_NAME${NC}"
+    echo ""
+    read -p "Press Enter when installation is complete..."
+done
+
+echo ""
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}Setup Complete!${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+echo -e "Created apps:${CREATED_APPS}"
+echo ""
+echo "Secrets stored in repository:"
+for app_key in "${!APPS[@]}"; do
+    SECRET_PREFIX=$(echo "$app_key" | tr '[:lower:]-' '[:upper:]_')
+    echo "  - ${SECRET_PREFIX}_APP_ID"
+    echo "  - ${SECRET_PREFIX}_PRIVATE_KEY"
+done
+echo ""
+echo -e "${YELLOW}Next steps:${NC}"
+echo "  1. Update workflow files to use the new app tokens"
+echo "  2. See docs/GITHUB_APPS.md for workflow integration guide"
+echo ""


### PR DESCRIPTION
## Summary

Adds infrastructure for migrating from PAT-based authentication to GitHub Apps, giving each agent a distinct identity.

## Problem

Currently all agents appear as `claude[bot]` or `github-actions[bot]`, causing:
- No distinction between agents in audit trail
- Bot comments don't trigger workflows (GitHub security feature)
- Can't assign issues to agents
- @mentions are just text patterns, not real user references

## Solution

GitHub Apps for each agent role:

| Agent | App | Identity |
|-------|-----|----------|
| Code Agent | DP Code Agent | `@dp-code-agent[bot]` |
| Factory Manager | DP Factory Manager | `@dp-factory-manager[bot]` |
| DevOps | DP DevOps Agent | `@dp-devops[bot]` |
| Triage | DP Triage Agent | `@dp-triage[bot]` |
| QA | DP QA Agent | `@dp-qa[bot]` |

## New Files

- `.github/apps/*.json` - App manifests (5 files)
- `scripts/setup-github-apps.sh` - Interactive setup script
- `docs/GITHUB_APPS.md` - Comprehensive documentation
- `.github/examples/bug-fix-with-app.yml.example` - Migration example

## How to Migrate

1. Run `./scripts/setup-github-apps.sh`
2. Update workflows to use `actions/create-github-app-token@v1`
3. Test each agent's identity

## Benefits

1. Each agent has distinct identity
2. Bot comments CAN trigger workflows
3. Issues can be assigned to agent bot accounts
4. Scoped permissions per agent
5. Clear audit trail

## Test Plan

- [ ] Run setup script and create apps
- [ ] Verify secrets are stored
- [ ] Test one workflow with app token
- [ ] Verify comments appear from correct bot identity