### PR TITLE
fix(devops): trigger Code Agent for feedback-originated issues

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -874,6 +874,14 @@ jobs:
             if [ $? -eq 0 ]; then
               echo "✅ Created issue: $ISSUE_URL"
 
+              # Extract issue number and trigger Code Agent
+              # (Feedback issues have pre-assigned labels so Triage Agent skips them)
+              ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+              if [ -n "$ISSUE_NUM" ]; then
+                echo "Triggering Code Agent on issue #$ISSUE_NUM..."
+                gh issue comment "$ISSUE_NUM" --body "@code This issue was created from user feedback. Please investigate and address the user's ${FEEDBACK_TYPE} report." || echo "::warning::Failed to trigger Code Agent for issue #$ISSUE_NUM"
+              fi
+
               # Mark feedback as processed with the issue URL
               PATCH_RESPONSE=$(curl -s -w "\n%{http_code}" -X PATCH \
                 --max-time 30 \


### PR DESCRIPTION
## Summary
- Fixes the feedback processing gap where user feedback issues never triggered the Code Agent
- Feedback issues have pre-assigned labels (bug/enhancement), causing Triage Agent to skip them
- Now posts `@code` comment immediately after creating feedback issue to trigger Code Agent

## Root Cause
1. `process-feedback` job creates issues with labels like `bug,priority-medium,user-feedback`
2. Triage Agent skips issues that already have triage labels
3. Result: No `@code` comment → Code Agent never triggered → feedback sits idle

## Fix
After creating a feedback issue, immediately post a `@code` comment with context about the feedback type.

## Test Plan
- [ ] Submit test feedback via the app
- [ ] Verify issue is created with labels
- [ ] Verify `@code` comment is posted
- [ ] Verify Code Agent workflow is triggered

Fixes #324