### PR TITLE
fix(factory-manager): pass github_token to claude-code-action

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -1355,6 +1355,7 @@ jobs:
       - name: Run Claude for diagnosis
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
           prompt: |
             You are the Factory Manager - a meta-agent responsible for monitoring and maintaining the autonomous software factory.
 
@@ -1602,6 +1603,7 @@ jobs:
       - name: Run Claude for deep diagnosis
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
           prompt: |
             You are the Factory Manager performing a deep diagnosis of issue #${{ github.event.inputs.issue_number }}.
 


### PR DESCRIPTION
## Summary
Fixes the root cause of Factory Manager being unable to push workflow changes.

**Problem:** Factory Manager kept reporting "GitHub App lacks workflows permission" even though `PAT_WITH_WORKFLOW_ACCESS` was configured.

**Root Cause:** The `claude-code-action` uses the `github_token` input parameter for git operations, NOT the `GH_TOKEN`/`GITHUB_TOKEN` environment variables. Without `github_token`, it falls back to the default GITHUB_TOKEN (a GitHub App token without workflow scope).

**Fix:** Added `github_token: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}` to both `claude-code-action` steps in Factory Manager.

## Impact
Factory Manager can now autonomously:
- Modify `.github/workflows/*.yml` files
- Push workflow changes
- Create PRs for factory fixes

This is the whole point of Factory Manager - it should be able to heal and improve the factory without human intervention.

## Test Plan
- [ ] Trigger Factory Manager on an issue needing workflow changes
- [ ] Verify it can push to a branch with workflow file modifications
- [ ] Verify PR creation succeeds

Fixes #342