### PR TITLE
fix(factory): ensure feedback form submissions go through triage

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -823,15 +823,15 @@ jobs:
 
             echo "Processing feedback $FEEDBACK_ID (type: $FEEDBACK_TYPE)..."
 
-            # Determine labels based on feedback type
+            # Use only user-feedback label - let Triage Agent determine classification
+            LABELS="user-feedback"
+
+            # Set title prefix based on feedback type for context
             if [ "$FEEDBACK_TYPE" = "bug" ]; then
-              LABELS="bug,priority-medium,user-feedback"
               TITLE_PREFIX="🐛 [User Bug Report]"
             elif [ "$FEEDBACK_TYPE" = "feature" ]; then
-              LABELS="enhancement,priority-medium,user-feedback"
               TITLE_PREFIX="💡 [User Feature Request]"
             else
-              LABELS="question,priority-low,user-feedback"
               TITLE_PREFIX="💬 [User Feedback]"
             fi
 
@@ -874,12 +874,11 @@ jobs:
             if [ $? -eq 0 ]; then
               echo "✅ Created issue: $ISSUE_URL"
 
-              # Extract issue number and trigger Code Agent
-              # (Feedback issues have pre-assigned labels so Triage Agent skips them)
+              # Extract issue number and trigger Triage Agent first
               ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
               if [ -n "$ISSUE_NUM" ]; then
-                echo "Triggering Code Agent on issue #$ISSUE_NUM..."
-                gh issue comment "$ISSUE_NUM" --body "@code This issue was created from user feedback. Please investigate and address the user's ${FEEDBACK_TYPE} report." || echo "::warning::Failed to trigger Code Agent for issue #$ISSUE_NUM"
+                echo "Triggering Triage Agent on issue #$ISSUE_NUM..."
+                gh issue comment "$ISSUE_NUM" --body "@triage This issue was created from user feedback (type: ${FEEDBACK_TYPE}). Please triage and then trigger the appropriate agent to address the user's report." || echo "::warning::Failed to trigger Triage Agent for issue #$ISSUE_NUM"
               fi
 
               # Mark feedback as processed with the issue URL


### PR DESCRIPTION
## Factory Issue Fix

This fixes the factory issue identified in #346 where feedback form submissions were bypassing the Triage Agent.

### Problem
Feedback form submissions were going straight to the Code Agent because:
1. They were pre-assigned classification labels (bug, enhancement, question)
2. Triage Agent skips issues that already have these labels
3. Feedback processing directly triggered @code instead of @triage

### Solution
- Remove pre-assigned classification labels from feedback processing
- Use only 'user-feedback' label initially
- Trigger @triage instead of @code for feedback issues  
- Let Triage Agent properly classify and prioritize before triggering Code Agent

### Flow Before (BROKEN)


### Flow After (FIXED)


This ensures all issues follow the proper factory flow and get appropriate classification and prioritization.

Relates to #346