### PR TITLE
fix(factory): remove premature issue closure from Code Agent

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -1014,10 +1014,10 @@ jobs:
 
           cc @${ISSUE_AUTHOR}"
 
-                  # Explicitly close issue - GitHub's auto-close doesn't work when merging via API/CLI
-                  echo "Closing issue #${{ steps.context.outputs.number }}..."
-                  gh issue close ${{ steps.context.outputs.number }} \
-                    --comment "Closed by PR #${PR_NUMBER}" 2>/dev/null || echo "Issue already closed or not found"
+                  # NOTE: Do NOT close issue here - violates CLAUDE.md workflow rules!
+                  # Issues are closed by CI close-issues job AFTER deploy + smoke tests pass
+                  # This ensures issues are only marked "complete" when fixes are actually in production
+                  echo "PR #${PR_NUMBER} merged successfully - issue will close after deploy"
 
                   # Trigger CI/CD workflow via repository_dispatch since GITHUB_TOKEN merges don't trigger push events
                   echo "Triggering deploy via repository_dispatch..."


### PR DESCRIPTION
## Factory Bug Fix

**Problem:** Code Agent was violating CLAUDE.md workflow rules by closing issues immediately when CI passed, before deployment and smoke tests completed.

**Root Cause:** In bug-fix.yml line 1019, the workflow explicitly closed issues with:
```yaml
gh issue close ${{ steps.context.outputs.number }}
```

This violated CLAUDE.md rules:
> "Issues auto-close after deploy + smoke tests pass (handled by CI close-issues job)"

**Impact:** Issues #335/#340 were marked "complete" even though E2E tests failed and the French language fix was never deployed to production.

## Solution

**Changes Made:**
- ❌ Removed premature `gh issue close` command from bug-fix.yml
- ✅ Added explanatory comments about proper closure workflow  
- ✅ Issues now only close via CI `close-issues` job after successful deploy + smoke tests

**Workflow Flow (Fixed):**
1. Code Agent creates PR → CI tests → Auto-merge → Deploy → Smoke tests → **THEN** close issues
2. This ensures issues are only marked "complete" when fixes are actually in production

## Testing

- [x] YAML syntax validated
- [x] Workflow logic reviewed
- [x] Matches CLAUDE.md specifications

## Factory Improvement

This fix prevents future premature issue closures and ensures the autonomous factory follows proper deployment workflows.

Relates to #348