### PR TITLE
fix(factory): use PAT for triage workflow to support external users

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -79,6 +79,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         if: steps.check_triaged.outputs.skip != 'true'
         with:
+          github_token: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
           prompt: |
             Read CLAUDE.md and .claude/agents/triage-product.md first.
 


### PR DESCRIPTION
## Problem

The Triage Agent workflow fails when an issue is created by an external user (no write access to repository). The error shows:



## Root Cause

The  defaults to OIDC token exchange when no  parameter is provided. The OIDC token validation checks if the **issue reporter** has write access, not whether the workflow has proper permissions.

External users filing issues (the primary source of bug reports) don't have write access, causing the workflow to fail.

## Solution

Add  to the triage workflow, matching the approach used in . This bypasses OIDC token exchange and uses the PAT directly.

## Testing

This fix enables the Triage Agent to run on issues filed by external users, allowing the autonomous factory to properly intake and route all bug reports.

## Files Changed

-  - Added github_token parameter to use PAT instead of OIDC

Relates to #362