### PR TITLE
fix(factory): prevent duplicate Factory Manager responses via concurrency control

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -33,10 +33,10 @@ permissions:
   # NOTE: workflows permission is only valid for PATs, not workflow files
   # The PAT_WITH_WORKFLOW_ACCESS secret has this scope
 
-# Only one Factory Manager run at a time
+# Only one Factory Manager run at a time to prevent duplicate comments
 concurrency:
-  group: factory-manager
-  cancel-in-progress: false
+  group: factory-manager-${{ github.event.issue.number || 'global' }}
+  cancel-in-progress: true
 
 jobs:
   # ===========================================


### PR DESCRIPTION
Fixes #386

## Problem
Factory Manager posted duplicate replies on issue #385 (comments posted 8 seconds apart with identical content).

## Root Cause
Two Factory Manager workflow runs triggered simultaneously for the same @mention, both executing and posting identical comments. This happened because:
1. Concurrency group was global () instead of issue-specific
2.  allowed both runs to complete

## Solution
- **Issue-specific concurrency groups**: `factory-manager-${{ github.event.issue.number || 'global' }}`
- **Enable cancellation**: `cancel-in-progress: true` to prevent duplicate work
- **Maintain parallelism**: Different issues can still be processed simultaneously
- **Global fallback**: Scheduled runs (health checks) use 'global' group

## Testing
- Existing health check functionality preserved
- Multiple issues can be processed in parallel
- Same issue will only have one active Factory Manager run

Relates to #386