### PR TITLE
fix(factory): clarify Code Agent workflow delegation rules

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -331,14 +331,40 @@ jobs:
             **You have PAT_WITH_WORKFLOW_ACCESS which grants FULL repository permissions:**
             - ✅ Can trigger workflows via `gh workflow run` or `repository_dispatch`
             - ✅ Can merge PRs via `gh pr merge`
-            - ✅ Can modify ANY file including `.github/workflows/`
             - ✅ Can create/close issues and PRs
             - ✅ Can push to any branch
+            - ✅ Can modify most files, BUT see delegation rules below
 
             **DO NOT claim you "don't have permission" without actually trying!**
             - If you think you can't do something, TRY IT FIRST
             - Only escalate if the command actually fails with a permission error
             - Being overly conservative wastes human time on things you CAN do
+
+            ## 🏭 FACTORY DELEGATION RULES
+
+            **For factory-level changes, delegate to Factory Manager instead of doing them yourself:**
+
+            **DELEGATE these changes to @factory-manager:**
+            - ✋ Modifications to `.github/workflows/` files
+            - ✋ Changes to agent behavior/prompts in workflow files
+            - ✋ Updates to CLAUDE.md that affect multiple agents
+            - ✋ Changes to concurrency patterns or workflow triggers
+
+            **How to delegate:**
+            ```bash
+            gh issue comment ${{ steps.context.outputs.number }} --body "@factory-manager this requires a workflow change: [explain what needs changing and why]"
+            ```
+
+            **Still do yourself (even if they touch workflow files):**
+            - ✅ Bug fixes to application code
+            - ✅ New feature implementations
+            - ✅ Test updates
+            - ✅ Documentation that doesn't affect agent behavior
+
+            **Why delegate factory changes?**
+            - Factory Manager has broader context across all agents
+            - Prevents conflicts between concurrent agent workflow modifications
+            - Maintains proper separation between product changes (you) and factory changes (FM)
 
             ## 📝 DOCUMENT FACTORY FIXES!
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -681,20 +681,33 @@ The QA agent performs **periodic reflection and enhancement** of the test suite:
 
 ### Workflow File Changes
 
-**Code Agent CAN modify `.github/workflows/` files** when the checkout uses `PAT_WITH_WORKFLOW_ACCESS`:
+**Factory Manager handles workflow modifications** to maintain proper separation between product changes and factory changes.
 
-```yaml
-- uses: actions/checkout@v4
-  with:
-    token: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
+**Code Agent Delegation Rule:**
+When a Code Agent needs workflow changes, it should delegate to Factory Manager:
+```bash
+gh issue comment ISSUE_NUMBER --body "@factory-manager this requires a workflow change: [explain what and why]"
 ```
 
-The bug-fix.yml workflow is already configured this way. If you need to modify workflow files:
-1. Make your changes to `.github/workflows/*.yml`
-2. Commit and push normally - the PAT token enables this
-3. Create PR as usual
+**What Code Agent should delegate:**
+- ✋ Modifications to `.github/workflows/` files
+- ✋ Changes to agent prompts/behavior in workflows
+- ✋ Updates to CLAUDE.md affecting multiple agents
+- ✋ Concurrency or trigger pattern changes
 
-**Do NOT assume you can't push workflow files** - this was a past limitation that has been fixed.
+**What Code Agent can still do:**
+- ✅ Application code changes (even if they happen to touch workflow config files as data)
+- ✅ Test updates
+- ✅ Bug fixes
+- ✅ New feature implementations
+
+**Why this separation?**
+- Factory Manager has broader context across all agents
+- Prevents conflicts from concurrent workflow modifications
+- Maintains factory vs. product change distinction
+- Avoids confusion from mixed "can modify" vs. "should delegate" signals
+
+**Technical note:** Code Agent workflows are configured with `PAT_WITH_WORKFLOW_ACCESS` for technical capabilities, but the **delegation pattern ensures proper factory management**.
 
 ### Workflow Concurrency Pattern
 


### PR DESCRIPTION
## Factory Issue Fixed

Resolves #391

### Problem
Code Agent was getting confused by mixed signals about workflow file modifications:
- Workflow comment said "delegates to Factory Manager"
- But prompt said "Can modify ANY file including .github/workflows/"
- Agent got stuck trying to modify workflows instead of delegating

### Root Cause
Inconsistent messaging about whether Code Agent **can** vs. **should** modify workflow files.

### Solution
**Clarified delegation pattern:**
- Code Agent **has** technical capability (PAT_WITH_WORKFLOW_ACCESS)
- But **should delegate** factory-level changes to Factory Manager
- Clear rules about what to delegate vs. what to do directly

### Changes Made

1. **Updated Code Agent workflow prompt** ():
   - Added "FACTORY DELEGATION RULES" section
   - Clear list of what to delegate (workflows, agent behavior, CLAUDE.md changes)
   - Clear list of what to still do directly (app code, tests, features)
   - Instructions on how to delegate with @factory-manager mention

2. **Updated CLAUDE.md**:
   - Rewrote "Workflow File Changes" section
   - Documented the delegation pattern
   - Explained why we separate factory vs. product changes
   - Maintains technical capability while ensuring proper escalation

### Benefits
- ✅ No more Code Agent confusion about workflow permissions
- ✅ Clear separation: product changes (Code Agent) vs. factory changes (Factory Manager)
- ✅ Prevents conflicts from concurrent workflow modifications
- ✅ Factory Manager maintains broader context across all agents

### Factory Learning
This addresses a common pattern where agents get mixed signals about their capabilities vs. their responsibilities. The fix maintains technical capability while ensuring proper workflow management.

Relates to #391