### PR TITLE
fix(factory): improve Factory Manager fallback detection

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -1450,15 +1450,32 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          # Check if Factory Manager posted a substantive comment (not just "Analyzing...")
+          # Check total comment count to adjust timeout for large issues
+          COMMENT_COUNT=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments \
+            --jq 'length' 2>/dev/null || echo "0")
+
+          # Base timeout is 5 minutes, add 2 minutes for every 10 comments beyond 20
+          BASE_TIMEOUT=300
+          if [ "$COMMENT_COUNT" -gt 20 ]; then
+            EXTRA_MINUTES=$(( (COMMENT_COUNT - 20) / 10 * 2 ))
+            TIMEOUT_SECONDS=$(( BASE_TIMEOUT + EXTRA_MINUTES * 60 ))
+          else
+            TIMEOUT_SECONDS=$BASE_TIMEOUT
+          fi
+
+          echo "Issue has $COMMENT_COUNT comments, using ${TIMEOUT_SECONDS}s timeout"
+
+          # Check for any substantive Factory Manager response (more flexible detection)
           RECENT_RESPONSE=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments \
-            --jq '[.[] | select(
-              (.body | contains("[Factory Manager]")) and
-              ((.created_at | fromdateiso8601) > (now - 300))
+            --jq --arg timeout_ago "$(date -d "@$(( $(date +%s) - $TIMEOUT_SECONDS ))" -Iseconds)" \
+            '[.[] | select(
+              ((.user.login == "github-actions[bot]" and (.body | contains("Factory Manager"))) or
+               (.body | contains("[Factory Manager]"))) and
+              (.created_at > $timeout_ago)
             )] | length' 2>/dev/null || echo "0")
 
           if [ "$RECENT_RESPONSE" -eq 0 ]; then
-            echo "⚠️ Claude didn't post a response comment - posting fallback"
+            echo "⚠️ No Factory Manager response found within ${TIMEOUT_SECONDS}s - posting fallback"
             {
               echo "## [Factory Manager] Response"
               echo ""
@@ -1472,9 +1489,11 @@ jobs:
               echo "**Next steps:**"
               echo "- Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for my full analysis"
               echo "- If urgent, try \`@factory-manager\` again or contact @jeremymatthewwerner"
+              echo ""
+              echo "*Note: This issue has $COMMENT_COUNT comments - extended timeout to ${TIMEOUT_SECONDS}s*"
             } | gh issue comment "$ISSUE_NUMBER" --repo ${{ github.repository }} --body-file -
           else
-            echo "✅ Factory Manager posted a response"
+            echo "✅ Factory Manager posted a response within ${TIMEOUT_SECONDS}s"
           fi
 
   # ===========================================


### PR DESCRIPTION
## Summary

Fixes Factory Manager fallback triggering false positives on large issues.

**Problem:** Factory Manager was posting generic fallback responses even when claude-code-action was working correctly, especially on large issues with 20+ comments.

**Root Cause:**
- Fixed 5-minute timeout was too short for large issues
- Response detection was too strict, only looking for exact  text
- Race condition between claude posting response and fallback check

**Solution:**
- **Dynamic timeout:** Base 5min + 2min per 10 comments beyond 20 comments
- **Flexible detection:** Check for  text in any form, from any relevant user
- **Better logging:** Show comment count and timeout used for debugging

## Changes

- Modified  fallback detection logic
- Combines Option 1 (flexible detection) and Option 2 (timeout scaling) from issue description
- Backward compatible - still catches real failures appropriately

## Testing

- Issue #394 (30+ comments) would now use 9-minute timeout instead of 5-minute
- Detection catches both  headers and regular text containing 'Factory Manager'
- Fallback messages now include debug info about comment count and timeout

Relates to #435