### PR TITLE
chore(sync): add missing agent docs to template-sync

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -71,8 +71,14 @@ jobs:
             ".github/workflows/product-manager.yml"
             "CLAUDE.md"
             "REQUIREMENTS.md"
-            "docs/OBSERVABILITY.md"
+            "docs/CODE_AGENT.md"
+            "docs/DEVOPS.md"
             "docs/FACTORY_MANAGER.md"
+            "docs/OBSERVABILITY.md"
+            "docs/PRINCIPAL_ENGINEER.md"
+            "docs/QA_AGENT.md"
+            "docs/RELEASE_ENG.md"
+            "docs/TRIAGE.md"
             "scripts/flaky-test-hunter.sh"
           )
 


### PR DESCRIPTION
## Summary
Adds missing agent documentation files to the template-sync workflow so they get synced to the template repository.

## Files Added to Sync
- `docs/CODE_AGENT.md`
- `docs/DEVOPS.md`
- `docs/PRINCIPAL_ENGINEER.md`
- `docs/QA_AGENT.md`
- `docs/RELEASE_ENG.md`
- `docs/TRIAGE.md`

## Test Plan
- [ ] Verify template-sync workflow runs on merge
- [ ] Verify docs appear in template repo after sync

Relates to factory improvements