### PR TITLE
docs: add AGENT_REFERENCE.md and update README with 11 agents

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -79,6 +79,7 @@ jobs:
             "docs/QA_AGENT.md"
             "docs/RELEASE_ENG.md"
             "docs/TRIAGE.md"
+            "docs/AGENT_REFERENCE.md"
             "scripts/flaky-test-hunter.sh"
           )
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,21 @@ Real-time multi-party chat with AI-simulated historical and contemporary thinker
 
 ## Autonomous Software Factory
 
-This repository uses 9 AI-powered GitHub Actions agents for autonomous development:
+This repository uses 11 AI-powered GitHub Actions agents for autonomous development:
 
 | Agent | Trigger | Purpose |
 |-------|---------|---------|
 | **Triage** | Issue opened | Classifies issues, detects duplicates, adds labels |
-| **Code Agent** | `@code` mention in comment | Diagnoses and fixes issues, creates PRs |
-| **Principal Engineer** | `@pe` mention in comment | Holistic debugging, fixes factory not just symptoms |
-| **Factory Manager** | Every 5 min + `@factory-manager` mention | Monitors factory health, detects stuck issues, auto-fixes |
+| **Code Agent** | `@code` mention | Diagnoses and fixes issues, creates PRs |
+| **Principal Engineer** | `@pe` mention | Holistic debugging, fixes factory not just symptoms |
+| **Product Manager** | `@pm` mention | Processes roadmaps, creates tracking sub-issues |
+| **Factory Manager** | Every 30 min + `@factory-manager` | Monitors factory health, detects stuck issues |
 | **QA** | Nightly 2am UTC | Improves test coverage, hunts flaky tests |
 | **Release Eng** | Daily 3am UTC | Security audits, dependency updates |
-| **DevOps** | `@devops` mention + Every 5 min + push to main | Health checks, incident response, auto-merge |
+| **DevOps** | `@devops` + Every 5 min + push to main | Health checks, incident response, auto-merge |
 | **Marketing** | On release | Updates changelog, docs |
 | **CI Monitor** | On CI failure (main) | Auto-creates issues and triggers Code Agent |
+| **iOS Native** | `@ios` mention | Native iOS development with Swift/SwiftUI |
 
 Add `ANTHROPIC_API_KEY` to repo secrets to enable automation.
 
@@ -39,7 +41,9 @@ Add `ANTHROPIC_API_KEY` to repo secrets to enable automation.
 |---------|-------|---------|
 | `@code` | Code Agent | `@code please fix this bug` |
 | `@pe` | Principal Engineer | `@pe this needs holistic investigation` |
+| `@pm` | Product Manager | `@pm please create tracking issues for this roadmap` |
 | `@devops` | DevOps Agent | `@devops check backend logs` |
+| `@ios` | iOS Native | `@ios please implement the settings view` |
 | `@factory-manager` | Factory Manager | `@factory-manager why is this stuck?` |
 
 **Examples:**

--- a/docs/AGENT_REFERENCE.md
+++ b/docs/AGENT_REFERENCE.md
@@ -1,0 +1,58 @@
+# Agent Reference
+
+This document lists all AI agents available in the software factory.
+
+## Agent Summary
+
+| Agent | Trigger | Purpose | Workflow |
+|-------|---------|---------|----------|
+| **Triage** | Issue opened | Classify, dedupe, prioritize, label | `triage.yml` |
+| **Code Agent** | `@code` mention | Fix bugs, implement features | `bug-fix.yml` |
+| **Principal Engineer** | `@pe` mention | Holistic debugging when Code Agent stuck | `principal-engineer.yml` |
+| **Product Manager** | `@pm` mention | Process roadmaps, create tracking sub-issues | `product-manager.yml` |
+| **Factory Manager** | Every 30 min + `@factory-manager` | Monitor factory health, detect stuck issues | `factory-manager.yml` |
+| **CI Monitor** | CI failure on main | Auto-create issues and trigger Code Agent | `ci-failure-monitor.yml` |
+| **DevOps** | Every 5 min + `@devops` | Production health, auto-merge ready PRs | `devops.yml` |
+| **QA** | 2am UTC daily | Improve test coverage | `qa.yml` |
+| **Release Eng** | 3am UTC daily | Security audits, dependencies | `release-eng.yml` |
+| **Marketing** | On release | Update changelog, docs | `marketing.yml` |
+
+## @Mentions
+
+Use these @mentions to trigger agents:
+
+| Mention | Agent | Use Case |
+|---------|-------|----------|
+| `@code` | Code Agent | Fix bugs, implement features |
+| `@pe` | Principal Engineer | Holistic debugging, factory fixes |
+| `@pm` | Product Manager | Process roadmaps, create tracking sub-issues |
+| `@devops` | DevOps Agent | Production logs, diagnostics, service restarts |
+| `@factory-manager` | Factory Manager | Check factory health, diagnose stuck issues |
+
+### Examples
+
+```
+@code please fix this bug
+@pe this issue needs holistic investigation
+@pm please create tracking issues for this roadmap
+@devops check backend logs for errors
+@factory-manager why is this issue stuck?
+```
+
+## Status Labels
+
+| Label | Meaning | Who Acts |
+|-------|---------|----------|
+| `status:bot-working` | Agent is actively working | Wait for agent |
+| `status:awaiting-human` | Agent needs your input | You respond |
+| `status:awaiting-bot` | You commented, agent will respond | Wait for agent |
+
+## Agent Documentation
+
+- [Code Agent](CODE_AGENT.md)
+- [Principal Engineer](PRINCIPAL_ENGINEER.md)
+- [DevOps](DEVOPS.md)
+- [Factory Manager](FACTORY_MANAGER.md)
+- [QA Agent](QA_AGENT.md)
+- [Release Engineering](RELEASE_ENG.md)
+- [Triage](TRIAGE.md)


### PR DESCRIPTION
## Summary
- Updates README.md with all 11 agents (adds Product Manager, iOS Native)
- Creates `docs/AGENT_REFERENCE.md` as canonical agent reference
- Adds AGENT_REFERENCE.md to template-sync

## Changes

**README.md:**
- 9 → 11 agents in factory section
- Added Product Manager (`@pm`) and iOS Native (`@ios`) to tables

**docs/AGENT_REFERENCE.md (new):**
- Canonical agent summary table
- @mentions reference
- Status labels
- Links to individual agent docs

**template-sync.yml:**
- Added `docs/AGENT_REFERENCE.md` to FILES array

## Why
The AGENT_REFERENCE.md provides a single source of truth that syncs to the template repo, ensuring agent information stays consistent across both repos.

## Test Plan
- [ ] Verify template-sync copies AGENT_REFERENCE.md
- [ ] Verify template repo gets the doc after sync

Relates to factory improvements