### PR TITLE
fix(factory): update Factory Manager respond job to use opus model

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -1468,7 +1468,7 @@ jobs:
 
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --model claude-sonnet-4-20250514
+            --model claude-opus-4-5-20251101
             --dangerously-skip-permissions
             --allowedTools "Bash(gh:*),Bash(git:*),Read,Write,Edit,Glob,Grep"
             --timeout ${{ steps.size_check.outputs.timeout_mins }}m


### PR DESCRIPTION
The respond job was crashing immediately with `Claude Code process exited with code 1`. 

Updated model from `claude-sonnet-4-20250514` to `claude-opus-4-5-20251101` (same as diagnose-issue job and Code Agent).

Relates to #454