### PR TITLE
fix(factory): remove invalid --timeout flag from Factory Manager

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -1471,7 +1471,6 @@ jobs:
             --model claude-opus-4-5-20251101
             --dangerously-skip-permissions
             --allowedTools "Bash(gh:*),Bash(git:*),Read,Write,Edit,Glob,Grep"
-            --timeout ${{ steps.size_check.outputs.timeout_mins }}m
         env:
           GH_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
           GITHUB_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
@@ -1734,7 +1733,6 @@ jobs:
             --model claude-opus-4-5-20251101
             --dangerously-skip-permissions
             --allowedTools "Bash(gh:*),Bash(git:*),Read,Write,Edit,Glob,Grep"
-            --timeout ${{ steps.size_check.outputs.timeout_mins }}m
         env:
           GH_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
           GITHUB_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}


### PR DESCRIPTION
## Summary
- Removed invalid --timeout flag from Factory Manager respond and diagnose-issue jobs
- This flag was causing Claude CLI to crash immediately with exit code 1

## Root Cause
The claude_args included --timeout 45m which Claude CLI couldn't parse.

## Solution
Removed the --timeout flag entirely. The workflow-level timeout-minutes setting handles job timeouts.

Relates to #454