### PR TITLE
fix(factory): accept factory-meta label as valid triage in canary tests

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -1172,11 +1172,16 @@ jobs:
 
           echo "Current labels: $LABELS"
 
-          if [[ "$LABELS" == *"bug"* ]] || [[ "$LABELS" == *"enhancement"* ]]; then
+          # Triage is considered successful if:
+          # 1. Issue has bug/enhancement label (normal triage), OR
+          # 2. Issue has factory-meta label (Triage correctly identified it as a factory/canary issue)
+          # The Triage Agent may correctly classify canary tests as factory-meta issues,
+          # which is the RIGHT behavior and should be counted as successful triage.
+          if [[ "$LABELS" == *"bug"* ]] || [[ "$LABELS" == *"enhancement"* ]] || [[ "$LABELS" == *"factory-meta"* ]]; then
             echo "✓ Triage PASSED: Issue was triaged with appropriate labels"
             echo "triage_passed=true" >> $GITHUB_OUTPUT
           else
-            echo "::warning::Triage may have failed: No bug/enhancement label found"
+            echo "::warning::Triage may have failed: No bug/enhancement/factory-meta label found"
             echo "triage_passed=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Summary

Fixes false positive in canary test verification that was incorrectly marking triage as "failed".

## Problem

The daily canary test on issue #474 was marked as "FAILED" even though the Triage Agent correctly:
1. Identified the canary issue as a factory/automation issue
2. Applied `factory-meta` and `priority-low` labels
3. Correctly excluded it from Code Agent triggering

The canary verification logic only checked for `bug` or `enhancement` labels, failing to recognize that `factory-meta` is also a valid triage outcome.

## Root Cause

The Triage Agent correctly classified canary test issues as `factory-meta` (which is the right behavior for automation/test issues), but the canary verification logic at line 1173-1181 only accepted `bug` or `enhancement` as valid triage labels.

## Solution

Updated the canary triage verification to also accept `factory-meta` as a valid triage outcome. This recognizes that when the Triage Agent correctly identifies an issue as factory-related, that's successful triage - not a failure.

## Testing

This fix will be validated by the next daily canary test (runs at 12pm UTC).

Relates to #475