### PR TITLE
fix(factory): prevent Factory Manager from responding to closed issues

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -1316,6 +1316,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' &&
       !github.event.issue.pull_request &&
+      github.event.issue.state == 'open' &&
       (contains(github.event.comment.body, '@factory-manager') ||
        contains(github.event.comment.body, '@Factory-Manager'))
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Fixes Factory Manager workflow responding multiple times to closed canary test issues
- Adds `github.event.issue.state == 'open'` check to the respond job

## Problem
Issue #478 was a canary test that completed successfully and was closed. However, because the Triage Agent's comment included `@factory-manager`, the workflow kept getting triggered on the closed issue, resulting in 17 duplicate responses.

## Root Cause
The `respond` job in factory-manager.yml didn't check if the issue was open before responding to `@factory-manager` mentions.

## Fix
Added `github.event.issue.state == 'open'` condition to prevent responding to closed issues.

## Test plan
- [x] Verify the fix in the workflow file
- [ ] CI passes
- [ ] Next canary test doesn't create duplicate responses on closure

Relates to #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)