### PR TITLE
fix(ci): increase E2E timeout from 15 to 25 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,8 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: [changes, backend, frontend]
-    # Timeout after 15 minutes to prevent stuck jobs
-    timeout-minutes: 15
+    # Timeout after 25 minutes - E2E suite has 149 tests which can take 15-20 min
+    timeout-minutes: 25
     # Only run E2E on PRs (not on push to main) - PR E2E is sufficient
     # This avoids running E2E twice (once on PR, once on merge)
     # always() ensures condition is evaluated even when dependent jobs are skipped


### PR DESCRIPTION
## Summary
- Increases E2E job timeout from 15 to 25 minutes
- The E2E test suite has grown to 149 tests which can take 15-20 minutes to complete
- The previous 15-minute timeout was causing CI to be cancelled on PR builds

## Root Cause
The E2E job was configured with `timeout-minutes: 15`, but actual E2E runs were taking ~14+ minutes just for test execution (not counting setup). This caused CI to be cancelled mid-run, blocking PRs from being merged.

## Impact
This fix unblocks:
- PR #494 (fix @mention alignment)
- Any other PRs waiting on E2E tests

Relates to #493

🤖 Generated with [Claude Code](https://claude.ai/code)