### PR TITLE
fix(factory): increase E2E timeout threshold from 10 to 20 minutes

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -287,8 +287,11 @@ jobs:
             --limit 20 \
             --json databaseId,name,headBranch,createdAt | jq '[.[] | select(.name == "CI/CD")]' 2>/dev/null || echo "[]")
 
-          # For each run, check if E2E Tests job has been running >10 min
-          THRESHOLD_SECS=600  # 10 minutes
+          # For each run, check if E2E Tests job has been running too long
+          # NOTE: This threshold MUST be less than CI's E2E timeout (currently 25 min in ci.yml)
+          # The test suite has grown to 149+ tests with Claude API calls, taking 15-20 min legitimately
+          # Set to 20 min to allow normal completion while catching truly stuck runs
+          THRESHOLD_SECS=1200  # 20 minutes (aligned with CI's 25-min E2E timeout)
           NOW_SECS=$(date +%s)
 
           STUCK_RUNS=$(echo "$IN_PROGRESS_RUNS" | jq -c '.[]' | while read -r run; do


### PR DESCRIPTION
## Summary

Factory Manager was cancelling legitimate E2E test runs after 10 minutes, blocking PR #495 (@mention autocomplete feature).

## Root Cause

**Threshold mismatch:**
- Factory Manager: 10-minute threshold for "stuck" E2E tests
- CI workflow: 25-minute timeout for E2E tests  
- Actual E2E suite: 15-20 minutes with 149 tests

## Changes

- Increased `THRESHOLD_SECS` from 600 (10 min) to 1200 (20 min) in `factory-manager.yml`
- Added inline documentation explaining the relationship to CI's E2E timeout
- This aligns with PR #496 which already increased CI timeout to 25 minutes

## Impact

- Unblocks PR #495 (feature: @mention autocomplete)
- Prevents premature E2E cancellation for future PRs
- Maintains ability to catch truly stuck runs (>20 min)

## Testing

After merge:
1. PR #495's E2E tests should complete without being cancelled
2. Factory Manager health check should no longer flag normal E2E runs

Relates to #492, #498

🤖 Generated with [Claude Code](https://claude.ai/code)