### PR TITLE
fix(factory): use env var for comment body in PE workflow quoting

### DIFF
--- a/.github/workflows/principal-engineer.yml
+++ b/.github/workflows/principal-engineer.yml
@@ -47,9 +47,11 @@ jobs:
       - name: Validate trigger is legitimate
         id: validate
         if: github.event_name == 'issue_comment'
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           # Strip code blocks from comment body to avoid false triggers
-          COMMENT_BODY='${{ github.event.comment.body }}'
+          # Note: Using env var to safely handle special characters (quotes, apostrophes, etc.)
 
           # Remove fenced code blocks (```...```)
           STRIPPED=$(echo "$COMMENT_BODY" | sed '/^```/,/^```/d')


### PR DESCRIPTION
## Summary
- Fixes shell quoting vulnerability in `principal-engineer.yml` workflow that caused CI failures

## Root Cause
The "Validate trigger is legitimate" step embedded the comment body directly into a single-quoted string:
```bash
COMMENT_BODY='${{ github.event.comment.body }}'
```

When a comment contains special characters like single quotes (e.g., `don't`), parentheses (e.g., `function()`), or backticks (common in technical discussions), this breaks shell parsing with errors like:
- `syntax error near unexpected token ')'`
- `unexpected EOF while looking for matching `'`

## Solution
Changed to use an environment variable to pass the comment body safely:
```yaml
env:
  COMMENT_BODY: ${{ github.event.comment.body }}
run: |
  # Use "$COMMENT_BODY" safely in the script
```

This follows the pattern already used in `devops.yml` (line 103).

## Test plan
- [x] Workflow syntax is valid
- [ ] CI should pass (workflow files only, no code tests needed)
- [ ] Verify PE workflow can handle comments with special characters

## Factory Improvement
This is a **factory bug fix**. The Code Agent correctly diagnosed the issue and delegated to Factory Manager per the CLAUDE.md delegation pattern.

Relates to #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)