### PR TITLE
fix(ci): only close issues for Fixes/Closes/Resolves, not Relates to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,13 +623,15 @@ jobs:
 
           ISSUE_NUMBERS=""
 
-          # For each PR, check its body for "Relates to #N"
+          # For each PR, check its body for "Fixes/Closes/Resolves #N"
           for PR_NUM in $PR_NUMBERS; do
             echo "Checking PR #$PR_NUM for issue references..."
             PR_BODY=$(gh pr view $PR_NUM --json body -q .body 2>/dev/null || echo "")
 
-            # Extract issue numbers from "Relates to #N" or "Fixes #N" patterns
-            REFS=$(echo "$PR_BODY" | grep -oE '(Relates to|Fixes|Closes|Resolves) #[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' || true)
+            # Extract issue numbers ONLY from "Fixes #N", "Closes #N", "Resolves #N" patterns
+            # IMPORTANT: Do NOT match "Relates to #N" - that indicates context, not a fix
+            # See issue #518 for the bug this pattern caused
+            REFS=$(echo "$PR_BODY" | grep -oE '(Fixes|Closes|Resolves) #[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' || true)
 
             if [ -n "$REFS" ]; then
               echo "  Found issue refs in PR #$PR_NUM: $REFS"
@@ -769,13 +771,15 @@ jobs:
 
           ISSUE_NUMBERS=""
 
-          # For each PR, check its body for "Relates to #N"
+          # For each PR, check its body for "Fixes/Closes/Resolves #N"
           for PR_NUM in $PR_NUMBERS; do
             echo "Checking PR #$PR_NUM for issue references..."
             PR_BODY=$(gh pr view $PR_NUM --json body -q .body 2>/dev/null || echo "")
 
-            # Extract issue numbers from "Relates to #N" or "Fixes #N" patterns
-            REFS=$(echo "$PR_BODY" | grep -oE '(Relates to|Fixes|Closes|Resolves) #[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' || true)
+            # Extract issue numbers ONLY from "Fixes #N", "Closes #N", "Resolves #N" patterns
+            # IMPORTANT: Do NOT match "Relates to #N" - that indicates context, not a fix
+            # See issue #518 for the bug this pattern caused
+            REFS=$(echo "$PR_BODY" | grep -oE '(Fixes|Closes|Resolves) #[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' || true)
 
             if [ -n "$REFS" ]; then
               echo "  Found issue refs in PR #$PR_NUM: $REFS"


### PR DESCRIPTION
## Summary

Fixes the CI close-issues job that was prematurely closing issues referenced with "Relates to #N" in PR bodies.

## Root Cause

The close-issues job's regex pattern was:
```bash
grep -oE '(Relates to|Fixes|Closes|Resolves) #[0-9]+'
```

This incorrectly treated "Relates to" as equivalent to "Fixes/Closes/Resolves", causing any issue mentioned for context to be closed upon deployment.

## What Happened

1. **PR #496** (E2E timeout increase) had `Relates to #493` in its body
2. **PR #502** (Factory Manager threshold) had `Relates to #492, #498` in its body
3. When these PRs merged and smoke tests passed, the close-issues job closed #492 and #493
4. But PRs #494 and #495 (the actual fixes for those issues) were still open and unmerged!

## The Fix

- Remove "Relates to" from the grep pattern
- Only close issues explicitly marked with "Fixes", "Closes", or "Resolves"
- Add comments explaining this distinction

## Pattern Semantics

| Pattern | Meaning | Should close? |
|---------|---------|---------------|
| `Fixes #N` | This PR fixes issue N | ✅ Yes |
| `Closes #N` | This PR closes issue N | ✅ Yes |
| `Resolves #N` | This PR resolves issue N | ✅ Yes |
| `Relates to #N` | Provides context only | ❌ No |

## Testing

The fix is straightforward regex change. After merge:
- Issues will only close when PRs explicitly use `Fixes`, `Closes`, or `Resolves`
- PRs can safely mention related issues for context without triggering auto-close

Relates to #518

🤖 Generated with [Claude Code](https://claude.ai/code)