### PR TITLE
fix(factory): update QA workflow with e2e-performance focus

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -13,7 +13,7 @@ on:
           - coverage-sprint
           - flaky-hunt
           - integration-gaps
-          - e2e-enhancement
+          - e2e-performance
           - edge-cases
           - test-refactoring
 
@@ -66,7 +66,7 @@ jobs:
             1) FOCUS="coverage-sprint" ;;
             2) FOCUS="flaky-hunt" ;;
             3) FOCUS="integration-gaps" ;;
-            4) FOCUS="e2e-enhancement" ;;
+            4) FOCUS="e2e-performance" ;;
             5) FOCUS="test-refactoring" ;;
             6) FOCUS="edge-cases" ;;
             7) FOCUS="regression-prevention" ;;
@@ -179,7 +179,7 @@ jobs:
             - **coverage-sprint**: Pick lowest coverage file, plan tests to increase by 15%+
             - **flaky-hunt**: Run test suite 5x, identify failures
             - **integration-gaps**: Find untested API endpoints
-            - **e2e-enhancement**: Plan edge case E2E tests
+            - **e2e-performance**: Optimize E2E test performance - reduce waitForTimeout calls, improve parallelism
             - **edge-cases**: Plan tests for error paths
             - **regression-prevention**: Review recent commits
 


### PR DESCRIPTION
## Summary
- Updates QA workflow to use `e2e-performance` focus on Thursdays (replacing `e2e-enhancement`)
- Completes the workflow change that Code Agent delegated to Factory Manager

## Context
This change supports PR #522 and issue #519. The Code Agent correctly identified that workflow file changes require Factory Manager (only Factory Manager has permissions to push to `.github/workflows/`).

## Changes to `.github/workflows/qa.yml`
1. **workflow_dispatch options** (line 16): `e2e-enhancement` → `e2e-performance`
2. **Day rotation case** (line 69): Thursday now uses `e2e-performance`
3. **Prompt focus descriptions** (line 182): Updated description for the new focus area

## Test plan
- [x] YAML syntax is valid (CI will verify)
- [ ] Next Thursday QA run will use `e2e-performance` focus

Relates to #519

🤖 Generated by Factory Manager