### PR TITLE
fix(ci): increase E2E timeout to 35 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,9 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: [changes, backend, frontend]
-    # Timeout after 25 minutes - E2E suite has 149 tests which can take 15-20 min
-    timeout-minutes: 25
+    # Timeout after 35 minutes - E2E suite has 149+ tests with Claude API calls
+    # Tests can take 25-30 min when API responses are slow
+    timeout-minutes: 35
     # Only run E2E on PRs (not on push to main) - PR E2E is sufficient
     # This avoids running E2E twice (once on PR, once on merge)
     # always() ensures condition is evaluated even when dependent jobs are skipped

--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -288,10 +288,10 @@ jobs:
             --json databaseId,name,headBranch,createdAt | jq '[.[] | select(.name == "CI/CD")]' 2>/dev/null || echo "[]")
 
           # For each run, check if E2E Tests job has been running too long
-          # NOTE: This threshold MUST be less than CI's E2E timeout (currently 25 min in ci.yml)
-          # The test suite has grown to 149+ tests with Claude API calls, taking 15-20 min legitimately
-          # Set to 20 min to allow normal completion while catching truly stuck runs
-          THRESHOLD_SECS=1200  # 20 minutes (aligned with CI's 25-min E2E timeout)
+          # NOTE: This threshold MUST be less than CI's E2E timeout (currently 35 min in ci.yml)
+          # The test suite has 149+ tests with Claude API calls, taking 25-30 min with slow API responses
+          # Set to 30 min to allow normal completion while catching truly stuck runs
+          THRESHOLD_SECS=1800  # 30 minutes (aligned with CI's 35-min E2E timeout)
           NOW_SECS=$(date +%s)
 
           STUCK_RUNS=$(echo "$IN_PROGRESS_RUNS" | jq -c '.[]' | while read -r run; do


### PR DESCRIPTION
## Summary

E2E tests are taking 25-30 minutes with slow Claude API responses, causing CI to timeout at 25 minutes.

## Changes

- **ci.yml**: E2E timeout increased from 25 to 35 minutes
- **factory-manager.yml**: Stuck detection threshold increased from 20 to 30 minutes

## Why

PRs #494 and #495 have been blocked for 2 days because E2E tests keep timing out. This fix will unblock them.

Relates to #492, #493, #518