### PR TITLE
fix(factory): move concurrency to job-level to prevent response cancellation

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -33,10 +33,14 @@ permissions:
   # NOTE: workflows permission is only valid for PATs, not workflow files
   # The PAT_WITH_WORKFLOW_ACCESS secret has this scope
 
-# Only one Factory Manager run at a time to prevent duplicate comments
-concurrency:
-  group: factory-manager-${{ github.event.issue.number || 'global' }}
-  cancel-in-progress: true
+# Concurrency is now handled per-job to allow different strategies:
+# - health-check jobs: cancel-in-progress: true (use latest data)
+# - respond/diagnose jobs: cancel-in-progress: false (let work complete)
+#
+# The old global concurrency group was cancelling Factory Manager responses
+# mid-execution when users mentioned @factory-manager multiple times,
+# preventing the agent from ever posting its full response.
+# See issue #534 for root cause analysis.
 
 jobs:
   # ===========================================
@@ -48,6 +52,12 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'full-health-check')
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    # Job-level concurrency: cancel older health checks in favor of newer ones
+    # Health checks should always use the latest data
+    concurrency:
+      group: factory-manager-health-check
+      cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@v4
@@ -1325,6 +1335,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 50  # Extended for large issues (30 -> 50)
 
+    # Job-level concurrency: let responses complete before starting new ones
+    # cancel-in-progress: false prevents the issue where multiple @factory-manager
+    # mentions cause responses to be cancelled mid-execution (see issue #534)
+    concurrency:
+      group: factory-manager-respond-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1628,6 +1645,12 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'diagnose-issue'
     runs-on: ubuntu-latest
     timeout-minutes: 50  # Extended for large issues
+
+    # Job-level concurrency: let diagnoses complete before starting new ones
+    # cancel-in-progress: false ensures full analysis is posted
+    concurrency:
+      group: factory-manager-diagnose-${{ github.event.inputs.issue_number || 'global' }}
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The global workflow concurrency group with `cancel-in-progress: true` was causing Factory Manager responses to be cancelled mid-execution whenever users mentioned `@factory-manager` multiple times on the same issue.

This is why Factory Manager has been posting fallback "encountered an issue posting my full response" messages for over a week.

### Root Cause

When a new `@factory-manager` mention triggers a new workflow run, the concurrency setting was cancelling the in-progress run before it could complete and post its response.

Looking at the workflow logs for the cancelled run (21101902818):
```
respond  2026-01-17T22:33:57.8983758Z Claude Code initialized
respond  2026-01-17T22:35:27.2200314Z ##[error]The operation was canceled.
```

The run was cancelled only ~2 minutes after Claude started processing, because a second `@factory-manager` mention triggered a new run.

### Fix

Move concurrency to job-level with appropriate strategies:
- **health-check**: `cancel-in-progress: true` (always use latest data)
- **respond**: `cancel-in-progress: false` (let responses complete)
- **diagnose-issue**: `cancel-in-progress: false` (let diagnoses complete)

This follows the pattern documented in CLAUDE.md for agent concurrency settings.

## Test Plan

- [ ] Trigger @factory-manager on an issue
- [ ] Before the response completes, trigger @factory-manager again
- [ ] Verify the first response completes instead of being cancelled
- [ ] Verify the second request is queued and runs after the first completes

Relates to #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)