### PR TITLE
fix(factory): improve fallback detection to recognize PAT-authored comments

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -1494,10 +1494,13 @@ jobs:
           SIZE_CONTEXT: ${{ steps.size_check.outputs.size_context }}
           COMMENT_COUNT: ${{ steps.size_check.outputs.comment_count }}
         run: |
-          # Improved fallback detection - check for any claude[bot] comment in last 15 minutes (author-based)
+          # Improved fallback detection - check for either:
+          # 1. claude[bot] comments (when posted via action's built-in mechanism)
+          # 2. Comments containing "[Factory Manager]" (when posted via gh using PAT)
+          # The PAT posts as the PAT owner, not as claude[bot]
           RECENT_RESPONSE=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments \
             --jq '[.[] | select(
-              (.user.login == "claude[bot]") and
+              ((.user.login == "claude[bot]") or (.body | contains("[Factory Manager]"))) and
               ((.created_at | fromdateiso8601) > (now - 900))
             )] | length' 2>/dev/null || echo "0")
 


### PR DESCRIPTION
## Summary

Fixes the Factory Manager fallback detection which was only checking for `claude[bot]` author, causing false positives when the agent posts comments via PAT.

## Problem

When Factory Manager posts comments using `gh issue comment` with `PAT_WITH_WORKFLOW_ACCESS`, comments appear as authored by the PAT owner (e.g., `jeremymatthewwerner`), not `claude[bot]`.

The fallback detection was only checking for `claude[bot]` author, causing it to always trigger and post a confusing "encountered an issue posting my full response" message even when the actual analysis was successfully posted.

## Solution

Now checks for EITHER:
1. `claude[bot]` author (action's built-in mechanism)  
2. Comments containing `[Factory Manager]` in body (PAT-posted)

## Test Plan

- [ ] Trigger Factory Manager via `@factory-manager` mention on an issue
- [ ] Verify no fallback message appears when analysis is successfully posted
- [ ] Verify fallback still triggers when no analysis is posted (timeout/error)

Relates to #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)