### PR TITLE
fix(factory): use allowed_bots instead of invalid allowed_actor_types

### DIFF
--- a/.github/workflows/bug-fix.yml
+++ b/.github/workflows/bug-fix.yml
@@ -306,6 +306,8 @@ jobs:
         if: steps.context.outputs.mode == 'fix'
         uses: anthropics/claude-code-action@v1
         with:
+          # Allow bot triggers for bot-to-bot coordination (Triage → Code Agent, Factory Manager → Code Agent)
+          allowed_bots: '*'
           prompt: |
             Read CLAUDE.md and .claude/agents/bug-fixer.md first.
 
@@ -619,6 +621,8 @@ jobs:
         if: steps.context.outputs.mode == 'respond'
         uses: anthropics/claude-code-action@v1
         with:
+          # Allow bot triggers for bot-to-bot coordination (Triage → Code Agent, Factory Manager → Code Agent)
+          allowed_bots: '*'
           prompt: |
             Read CLAUDE.md first.
 
@@ -722,6 +726,8 @@ jobs:
         if: steps.context.outputs.mode == 'continue'
         uses: anthropics/claude-code-action@v1
         with:
+          # Allow bot triggers for bot-to-bot coordination (Triage → Code Agent, Factory Manager → Code Agent)
+          allowed_bots: '*'
           prompt: |
             Read CLAUDE.md and .claude/agents/bug-fixer.md first.
 

--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -1392,7 +1392,7 @@ jobs:
         with:
           github_token: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
           # Allow bot triggers - Factory Manager may respond to issues with bot comments
-          allowed_actor_types: "User,Bot"
+          allowed_bots: '*'
           prompt: |
             You are the Factory Manager - a meta-agent responsible for monitoring and maintaining the autonomous software factory.
 
@@ -1689,7 +1689,7 @@ jobs:
         with:
           github_token: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
           # Allow bot triggers - Factory Manager may respond to issues with bot comments
-          allowed_actor_types: "User,Bot"
+          allowed_bots: '*'
           prompt: |
             You are the Factory Manager performing a deep diagnosis of issue #${{ github.event.inputs.issue_number }}.
 


### PR DESCRIPTION
## Summary
- Fix invalid `allowed_actor_types` parameter in Factory Manager workflow
- Add `allowed_bots: '*'` to all Code Agent claude-code-action instances
- Enable bot-to-bot coordination (Triage → Code Agent, Factory Manager → Code Agent)

## Root Cause
The `claude-code-action` uses `allowed_bots` (not `allowed_actor_types`) to control which bot actors can trigger the action. This was causing:
1. Factory Manager to fail with warnings about invalid parameter
2. Code Agent to reject bot-initiated triggers from Triage Agent and Factory Manager

## Changes
- **bug-fix.yml**: Add `allowed_bots: '*'` to all 3 `anthropics/claude-code-action@v1` instances (fix, respond, continue modes)
- **factory-manager.yml**: Replace invalid `allowed_actor_types: "User,Bot"` with `allowed_bots: '*'` in both respond and diagnose-issue jobs

## Test Plan
- [ ] CI passes on this PR
- [ ] After merge, verify bot-to-bot coordination works (e.g., Triage Agent can trigger Code Agent)

Relates to #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)