### PR TITLE
fix(factory): add allowed_bots to triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -83,6 +83,9 @@ jobs:
           # Allow ALL users to trigger triage - safe because this workflow only has
           # issues:write permission and only adds labels/comments
           allowed_non_write_users: '*'
+          # Allow bot-created issues to be triaged (e.g., factory-improvement issues,
+          # CI failure issues created by Factory Manager or CI Monitor)
+          allowed_bots: '*'
           prompt: |
             Read CLAUDE.md and .claude/agents/triage-product.md first.
 


### PR DESCRIPTION
## Summary
- Adds `allowed_bots: '*'` to the Triage Agent workflow to allow bot-created issues to be triaged
- Fixes the failure when triaging issues created by the `app/claude` bot (factory improvement issues, CI failure issues, etc.)

## Root Cause
The `claude-code-action` has two separate security controls:
1. `allowed_non_write_users` - allows non-repo-members to trigger (was already set to `*`)
2. `allowed_bots` - allows bots to trigger (was NOT set)

Since issue #556 was created by the `app/claude` bot, the Triage Agent workflow rejected it with:
> `Prepare step failed with error: Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.`

## Safety
This is safe because the Triage workflow only has `issues:write` permission and can only add labels/comments - no code modification access.

## Test plan
- [ ] CI passes
- [ ] Create a test issue via bot to verify triage works

Relates to #557

🤖 Generated with [Claude Code](https://claude.ai/claude-code)