### PR TITLE
fix(ci): add workflow-level permissions for repository_dispatch events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,14 @@ on:
   repository_dispatch:  # Triggered by claude-work after auto-merge (GITHUB_TOKEN can't trigger push)
     types: [deploy-after-merge]
 
+# Default permissions for all jobs
+# Required for repository_dispatch events which don't inherit default permissions
+# Job-level permissions can still override these as needed
+permissions:
+  contents: read
+  packages: write
+  issues: write
+
 env:
   REGISTRY: ghcr.io
   BACKEND_IMAGE: ghcr.io/${{ github.repository }}-backend


### PR DESCRIPTION
## Summary

- Adds workflow-level `permissions` block to `ci.yml` to fix Docker push failures when CI is triggered via `repository_dispatch` events

## Problem

When CI is triggered via `repository_dispatch` (from `bug-fix.yml` after auto-merge), job-level permissions aren't properly inherited by the `GITHUB_TOKEN`. This caused:

```
ERROR: failed to push ghcr.io/jeremymatthewwerner/dining-philosophers-dec25-sw-factory-backend:latest: denied: permission_denied: write_package
```

## Solution

Add a workflow-level `permissions` block that applies to all jobs by default:

```yaml
permissions:
  contents: read
  packages: write
  issues: write
```

This ensures the `GITHUB_TOKEN` has the necessary permissions regardless of how the workflow was triggered. Job-level permissions can still override these as needed.

## Test Plan

- [ ] Merge this PR
- [ ] CI should pass for the push event
- [ ] Future `repository_dispatch` triggers should successfully push Docker images

Relates to #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)