### PR TITLE
fix(factory): handle curl timeout in process-feedback job

### DIFF
--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -830,8 +830,22 @@ jobs:
           fi
 
           echo "Fetching pending feedback from $BACKEND_URL/api/feedback/pending..."
+
+          # Capture curl exit code separately to handle connection/timeout errors
+          set +e
           RESPONSE=$(curl -s -w "\n%{http_code}" --max-time 30 \
             "$BACKEND_URL/api/feedback/pending?secret=$SECRET&limit=10" 2>&1)
+          CURL_EXIT_CODE=$?
+          set -e
+
+          # Handle curl-level failures (timeout=28, connection refused=7, DNS=6, etc.)
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "::warning::curl failed with exit code $CURL_EXIT_CODE (timeout or connection error)"
+            echo "This is likely a transient issue - will retry on next scheduled run"
+            echo "has_feedback=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
           BODY=$(echo "$RESPONSE" | head -n-1)
 


### PR DESCRIPTION
## Summary
- Add resilient curl error handling to the `process-feedback` job in devops.yml
- Handles curl-level failures (timeout=28, connection refused=7, DNS=6, etc.)
- Treats transient network issues gracefully instead of failing the workflow

## Root Cause
The workflow was failing with curl exit code 28 (operation timed out). When curl itself fails, the bash script exited immediately due to `set -e` behavior in GitHub Actions. The script had proper HTTP error handling but not curl-level failure handling.

## Changes
- Use `set +e` before curl to prevent bash from exiting on curl failure
- Capture the curl exit code separately
- Handle transient failures gracefully (treat as "no feedback to process")
- Restore `set -e` after the curl call

This makes the workflow resilient to temporary network issues or backend latency.

## Test Plan
- [x] Verified the fix handles exit code 28 (timeout) gracefully
- [ ] Wait for CI to pass
- [ ] Verify next scheduled run doesn't fail due to transient issues

Relates to #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)