### PR TITLE
fix(factory): auto-cleanup factory-health issues older than 7 days

### DIFF
--- a/.github/workflows/factory-manager.yml
+++ b/.github/workflows/factory-manager.yml
@@ -960,6 +960,38 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cleanup old factory-health issues
+        env:
+          GH_TOKEN: ${{ secrets.PAT_WITH_WORKFLOW_ACCESS }}
+        run: |
+          echo "Cleaning up factory-health issues older than 7 days..."
+
+          # Calculate threshold (7 days ago)
+          THRESHOLD=$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')
+
+          # Find open factory-health issues older than 7 days
+          OLD_ISSUES=$(gh issue list \
+            --repo ${{ github.repository }} \
+            --label "factory-health" \
+            --state open \
+            --json number,title,createdAt | \
+            jq --arg threshold "$THRESHOLD" \
+            '[.[] | select(.createdAt < $threshold) | .number]' 2>/dev/null || echo "[]")
+
+          COUNT=$(echo "$OLD_ISSUES" | jq 'length')
+          echo "Found $COUNT old factory-health issues to close"
+
+          # Close each old issue
+          if [ "$COUNT" -gt 0 ]; then
+            echo "$OLD_ISSUES" | jq -r '.[]' | while read -r ISSUE_NUM; do
+              echo "Closing old factory-health issue #$ISSUE_NUM..."
+              gh issue close "$ISSUE_NUM" \
+                --repo ${{ github.repository }} \
+                --comment "Auto-closed: This factory health report is older than 7 days. A new report has been created." || true
+            done
+            echo "Cleanup complete: closed $COUNT old issues"
+          fi
+
       - name: Gather metrics
         id: metrics
         env:


### PR DESCRIPTION
## Summary
- Adds automatic cleanup for `factory-health` labeled issues older than 7 days
- Cleanup runs during the weekly report job (Monday 6am UTC)
- Old issues are closed with an explanatory comment

## Implementation
Added a new step to the `weekly-report` job in `factory-manager.yml` that:
1. Queries for open `factory-health` issues created more than 7 days ago
2. Closes each one with a comment explaining the auto-close

## Test plan
- [ ] Wait for next weekly report run (Monday 6am UTC) OR manually trigger via workflow_dispatch with `action: weekly-report`
- [ ] Verify old factory-health issues are closed with the expected comment
- [ ] Verify new weekly report is created successfully

Relates to #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)